### PR TITLE
Declare monaco-editor as peerDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@codingame/monaco-vscode-api",
       "version": "0.0.0-semantic-release",
       "license": "MIT",
-      "dependencies": {
-        "monaco-editor": "~0.34.1"
-      },
       "devDependencies": {
         "@babel/core": "^7.18.10",
         "@babel/plugin-proposal-class-properties": "^7.18.6",
@@ -5062,7 +5059,8 @@
     "node_modules/monaco-editor": {
       "version": "0.34.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
-      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
+      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==",
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -10687,7 +10685,8 @@
     "monaco-editor": {
       "version": "0.34.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
-      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
+      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==",
+      "peer": true
     },
     "ms": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "dependencies": {
-        "monaco-editor": "^0.34.0"
+        "monaco-editor": "~0.34.1"
       },
       "devDependencies": {
         "@babel/core": "^7.18.10",
@@ -45,6 +45,7 @@
         "zx": "^7.0.8"
       },
       "peerDependencies": {
+        "monaco-editor": "~0.34.0",
         "vscode-oniguruma": "^1.6.2",
         "vscode-textmate": "^7.0.1"
       }
@@ -5059,9 +5060,9 @@
       "dev": true
     },
     "node_modules/monaco-editor": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.0.tgz",
-      "integrity": "sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ=="
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
+      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -10684,9 +10685,9 @@
       "dev": true
     },
     "monaco-editor": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.0.tgz",
-      "integrity": "sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ=="
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
+      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
     "zx": "^7.0.8"
   },
   "dependencies": {
-    "monaco-editor": "~0.34.1"
   },
   "peerDependencies": {
     "monaco-editor": "~0.34.0",

--- a/package.json
+++ b/package.json
@@ -174,9 +174,10 @@
     "zx": "^7.0.8"
   },
   "dependencies": {
-    "monaco-editor": "^0.34.0"
+    "monaco-editor": "~0.34.1"
   },
   "peerDependencies": {
+    "monaco-editor": "~0.34.0",
     "vscode-textmate": "^7.0.1",
     "vscode-oniguruma": "^1.6.2"
   },


### PR DESCRIPTION
As discussed in https://github.com/TypeFox/monaco-languageclient/pull/435 `monaco-editor` is added as peerDependency. Additionally the range for both the dependency and the peerDependency is limited to >= 0.34.0 < 0.35.0 via "~".