### PR TITLE
Demo and Build improvements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,12 @@
     "es6": true,
     "browser": true
   },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module",
+    "project": "./tsconfig.eslint.json"
+},
   "globals": {
     "Thenable": "readonly",
     "VSCODE_VERSION": "readonly"
@@ -10,7 +16,13 @@
   "extends": [
     "@codingame"
   ],
-  "ignorePatterns": "vscode/**/*",
-  "plugins": ["@typescript-eslint", "import", "unused-imports"]
-
+  "ignorePatterns": [
+    "vscode/**/*",
+    "dist/**/*"
+  ],
+  "plugins": [
+    "@typescript-eslint",
+    "import",
+    "unused-imports"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "eslint.codeAction.showDocumentation": {
+    "enable": true
+  },
+  "eslint.validate": [
+    "javascript",
+    "typescript"
+  ],
+  "eslint.workingDirectories": [
+    "**/src/**/*.ts",
+    "./rollup/*.ts",
+    "./*.ts"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The VSCode api is composed of:
   - If it's an important feature: we let the user implement it as they wish.
   - If it's some advanced features that don't make a lot of sense on Monaco (debug, tests...), it just throws an error when you try to use it.
 
-
 To implement by hands the optional features (file system, workspace folders, file...), you can use the `Services` namespace from `vscode/services`:
+
 ```typescript
 import { Services } from 'vscode/services'
 Services.install({
@@ -37,6 +37,7 @@ This library allows you to use a more convenient way using `StandaloneServices.i
 Also, monaco-editor doesn't provide good type for them, so this library does it.
 
 Example:
+
 ```typescript
 import { StandaloneServices, INotificationService } from 'vscode/services'
 
@@ -49,6 +50,7 @@ StandaloneServices.initialize({
 ```
 
 Additionally, this library exposes 10 modules that include the vscode version of some services (with some glue to make it work with monaco):
+
 - Notifications: `vscode/service-override/notifications`
 - Dialogs: `vscode/service-override/dialogs`
 - Model / Editor: `vscode/service-override/modelEditor`
@@ -62,6 +64,7 @@ Additionally, this library exposes 10 modules that include the vscode version of
 - Token classification: `vscode/service-override/tokenClassification`
 
 Usage:
+
 ```typescript
 import { StandaloneServices } from 'vscode/services'
 import getModelEditorServiceOverride from 'vscode/service-override/modelEditor'
@@ -106,12 +109,14 @@ The editors created using `monaco.editor.create` don't use the configuration fro
 This library exposes functions to create editors binded on the configuration:
 
 before:
+
 ```typescript
 import * as monaco from 'monaco-editor'
 monaco.editor.create(...)
 ```
 
 after:
+
 ```typescript
 import { createConfiguredEditor } from 'vscode/monaco'
 
@@ -143,6 +148,7 @@ vscode.languages.registerCompletionItemProvider(...)
 
 There is a demo that showcases the service-override features. It allows to register contributions with the same syntaxes as in VSCode.
 It includes:
+
 - Languages
 - Language configurations
 - VSCode themes
@@ -157,10 +163,13 @@ It includes:
 It also uses the `getJsonSchemas` function to register them on the monaco json worker and have autocomplete/hover on settings and keybindings.
 
 From CLI run:
+
 ```bash
 cd demo
 npm ci
-npm start
+npm run start
+# OR: for vite debug output
+npm run start:debug
 ```
 
 ### History
@@ -170,17 +179,20 @@ This project was mainly created to make the implementation of [monaco-languagecl
 monaco-languageclient uses [vscode-languageclient](https://www.npmjs.com/package/vscode-languageclient) which was built to run inside a VSCode extension. VSCode extensions communicate with the editor via an [API](https://www.npmjs.com/package/@types/vscode) they can import into their code.
 
 [The VSCode api](https://code.visualstudio.com/api/references/vscode-api) exports:
+
 - Some functions to interact with the IDE ([language feature registrations](https://code.visualstudio.com/api/references/vscode-api#languages), [command execution](https://code.visualstudio.com/api/references/vscode-api#commands)...)
 - A lot of utility classes (Range, Position...)
 
 The first implementations of [monaco-languageclient](https://github.com/TypeFox/monaco-languageclient) were using a fake VSCode api implementation. The vscode-languageclient was hacked so the VSCode<->protocol object converters were mainly bypassed, so the fake VSCode api was receiving [Language Server Protocol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/) objects. Then the objects were transformed using custom transformers into [Monaco](https://www.npmjs.com/package/monaco-editor) objects to communicate with the monaco api.
 
 This approach has some disadvantages:
+
 - There is a lot of code to transform LSP objects into Monaco objects
 - It's hard to follow the updates of VSCode and the language server protocol
 - It doesn't behave exactly the same as in VSCode
 
 With this library, it would be possible to plug vscode-languageclient directly on top of monaco, monaco-languageclient still helps to do so by:
+
 - Adding some tweaks to the VSCode LanguageClient (Removing unsupported features...)
 - Providing a default implementations of the required fallback services (`vscode/services`)
 - Providing some examples on how to build an app using it

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -1,88 +1,75 @@
 {
   "name": "monaco-vscode-api-demo",
   "version": "0.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monaco-vscode-api-demo",
       "version": "0.0.0",
       "dependencies": {
-        "monaco-editor": "~0.34.0",
-        "throttle-debounce": "^5.0.0",
-        "vscode": "npm:@codingame/monaco-vscode-api@~1.69.21",
+        "monaco-editor": "~0.34.1",
+        "throttle-debounce": "~5.0.0",
+        "vscode": "file:../",
         "vscode-oniguruma": "~1.6.2"
       },
       "devDependencies": {
-        "@types/throttle-debounce": "^5.0.0",
-        "typescript": "^4.7.4",
-        "vite": "^3.0.9"
+        "@types/throttle-debounce": "~5.0.0",
+        "typescript": "~4.9.5",
+        "vite": "~4.1.4"
       }
     },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
-      "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@types/throttle-debounce": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
-      "integrity": "sha512-Pb7k35iCGFcGPECoNE4DYp3Oyf2xcTd3FbFQxXUI9hEYKUl6YX+KLf7HrBmgVcD05nl50LIH6i+80js4iYmWbw==",
-      "dev": true
-    },
-    "node_modules/esbuild": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
-      "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
+    "..": {
+      "name": "@codingame/monaco-vscode-api",
+      "version": "0.0.0-semantic-release",
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/core": "^7.21.0",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-decorators": "^7.21.0",
+        "@babel/preset-env": "^7.20.2",
+        "@babel/preset-typescript": "^7.21.0",
+        "@codingame/eslint-config": "^1.1.6",
+        "@codingame/tsconfig": "^1.1.1",
+        "@octokit/rest": "^19.0.7",
+        "@rollup/plugin-dynamic-import-vars": "^2.0.3",
+        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-replace": "^5.0.2",
+        "@rollup/plugin-typescript": "^11.0.0",
+        "@types/babel__core": "^7.20.0",
+        "@types/semver": "^7.3.13",
+        "@types/vscode": "~1.69.1",
+        "@typescript-eslint/eslint-plugin": "^5.54.0",
+        "@typescript-eslint/parser": "^5.54.0",
+        "eslint": "^8.35.0",
+        "eslint-config-standard": "^17.0.0",
+        "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-n": "^15.6.1",
+        "eslint-plugin-promise": "^6.1.1",
+        "eslint-plugin-unused-imports": "^2.0.0",
+        "js-cleanup": "^1.2.0",
+        "recast": "^0.22.0",
+        "rollup": "^3.17.3",
+        "rollup-plugin-dts": "^5.2.0",
+        "rollup-plugin-styles": "^4.0.0",
+        "semver": "^7.3.8",
+        "ts-node": "^10.9.1",
+        "typescript": "^4.9.5",
+        "webpack": "^5.75.0",
+        "zx": "^7.2.0"
       },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/linux-loong64": "0.14.54",
-        "esbuild-android-64": "0.14.54",
-        "esbuild-android-arm64": "0.14.54",
-        "esbuild-darwin-64": "0.14.54",
-        "esbuild-darwin-arm64": "0.14.54",
-        "esbuild-freebsd-64": "0.14.54",
-        "esbuild-freebsd-arm64": "0.14.54",
-        "esbuild-linux-32": "0.14.54",
-        "esbuild-linux-64": "0.14.54",
-        "esbuild-linux-arm": "0.14.54",
-        "esbuild-linux-arm64": "0.14.54",
-        "esbuild-linux-mips64le": "0.14.54",
-        "esbuild-linux-ppc64le": "0.14.54",
-        "esbuild-linux-riscv64": "0.14.54",
-        "esbuild-linux-s390x": "0.14.54",
-        "esbuild-netbsd-64": "0.14.54",
-        "esbuild-openbsd-64": "0.14.54",
-        "esbuild-sunos-64": "0.14.54",
-        "esbuild-windows-32": "0.14.54",
-        "esbuild-windows-64": "0.14.54",
-        "esbuild-windows-arm64": "0.14.54"
+      "peerDependencies": {
+        "monaco-editor": "~0.34.0",
+        "vscode-oniguruma": "^1.6.2",
+        "vscode-textmate": "^7.0.1"
       }
     },
-    "node_modules/esbuild-android-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
-      "integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
+      "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
       "cpu": [
-        "x64"
+        "arm"
       ],
       "dev": true,
       "optional": true,
@@ -93,10 +80,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-android-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
-      "integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
+      "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
       "cpu": [
         "arm64"
       ],
@@ -109,26 +96,26 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-darwin-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
-      "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
+      "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
       "optional": true,
       "os": [
-        "darwin"
+        "android"
       ],
       "engines": {
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
-      "integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
+      "integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
       "cpu": [
         "arm64"
       ],
@@ -141,26 +128,26 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
-      "integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
+      "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
       "optional": true,
       "os": [
-        "freebsd"
+        "darwin"
       ],
       "engines": {
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
-      "integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
+      "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
       "cpu": [
         "arm64"
       ],
@@ -173,42 +160,26 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-linux-32": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
-      "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
-      "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
+      "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
       "cpu": [
         "x64"
       ],
       "dev": true,
       "optional": true,
       "os": [
-        "linux"
+        "freebsd"
       ],
       "engines": {
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-linux-arm": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
-      "integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
+      "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
       "cpu": [
         "arm"
       ],
@@ -221,10 +192,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
-      "integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
+      "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
       "cpu": [
         "arm64"
       ],
@@ -237,10 +208,42 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
-      "integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
+      "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
+      "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
+      "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
       "cpu": [
         "mips64el"
       ],
@@ -253,10 +256,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
-      "integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
+      "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
       "cpu": [
         "ppc64"
       ],
@@ -269,10 +272,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
-      "integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
+      "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
       "cpu": [
         "riscv64"
       ],
@@ -285,10 +288,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
-      "integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
+      "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
       "cpu": [
         "s390x"
       ],
@@ -301,10 +304,26 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
-      "integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
+      "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
+      "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
       "cpu": [
         "x64"
       ],
@@ -317,10 +336,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
-      "integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
+      "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
       "cpu": [
         "x64"
       ],
@@ -333,10 +352,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-sunos-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
-      "integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
+      "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
       "cpu": [
         "x64"
       ],
@@ -349,10 +368,26 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-windows-32": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
-      "integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
+      "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
+      "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
       "cpu": [
         "ia32"
       ],
@@ -365,10 +400,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-windows-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
-      "integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
+      "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
       "cpu": [
         "x64"
       ],
@@ -381,20 +416,47 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
-      "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@types/throttle-debounce": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+      "integrity": "sha512-Pb7k35iCGFcGPECoNE4DYp3Oyf2xcTd3FbFQxXUI9hEYKUl6YX+KLf7HrBmgVcD05nl50LIH6i+80js4iYmWbw==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
+      "integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
       "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
       "engines": {
         "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.16.17",
+        "@esbuild/android-arm64": "0.16.17",
+        "@esbuild/android-x64": "0.16.17",
+        "@esbuild/darwin-arm64": "0.16.17",
+        "@esbuild/darwin-x64": "0.16.17",
+        "@esbuild/freebsd-arm64": "0.16.17",
+        "@esbuild/freebsd-x64": "0.16.17",
+        "@esbuild/linux-arm": "0.16.17",
+        "@esbuild/linux-arm64": "0.16.17",
+        "@esbuild/linux-ia32": "0.16.17",
+        "@esbuild/linux-loong64": "0.16.17",
+        "@esbuild/linux-mips64el": "0.16.17",
+        "@esbuild/linux-ppc64": "0.16.17",
+        "@esbuild/linux-riscv64": "0.16.17",
+        "@esbuild/linux-s390x": "0.16.17",
+        "@esbuild/linux-x64": "0.16.17",
+        "@esbuild/netbsd-x64": "0.16.17",
+        "@esbuild/openbsd-x64": "0.16.17",
+        "@esbuild/sunos-x64": "0.16.17",
+        "@esbuild/win32-arm64": "0.16.17",
+        "@esbuild/win32-ia32": "0.16.17",
+        "@esbuild/win32-x64": "0.16.17"
       }
     },
     "node_modules/fsevents": {
@@ -430,9 +492,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -442,9 +504,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.0.tgz",
-      "integrity": "sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ=="
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
+      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -471,9 +533,9 @@
       "dev": true
     },
     "node_modules/postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
       "dev": true,
       "funding": [
         {
@@ -512,15 +574,16 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.77.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
-      "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.17.3.tgz",
+      "integrity": "sha512-p5LaCXiiOL/wrOkj8djsIDFmyU9ysUxcyW+EKRLHb6TKldJzXpImjcRSR+vgo09DBdofGcOoLOsRyxxG2n5/qQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -556,9 +619,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -569,15 +632,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.9.tgz",
-      "integrity": "sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.1.4.tgz",
+      "integrity": "sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.14.47",
-        "postcss": "^8.4.16",
+        "esbuild": "^0.16.14",
+        "postcss": "^8.4.21",
         "resolve": "^1.22.1",
-        "rollup": ">=2.75.6 <2.77.0 || ~2.77.0"
+        "rollup": "^3.10.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -589,12 +652,17 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
+        "@types/node": ">= 14",
         "less": "*",
         "sass": "*",
         "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
         "less": {
           "optional": true
         },
@@ -604,354 +672,22 @@
         "stylus": {
           "optional": true
         },
+        "sugarss": {
+          "optional": true
+        },
         "terser": {
           "optional": true
         }
       }
     },
     "node_modules/vscode": {
-      "name": "@codingame/monaco-vscode-api",
-      "version": "1.69.21",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-1.69.21.tgz",
-      "integrity": "sha512-m+oLyRchCnv++oETMPXlkrw532hVM3v83atyG/2GA6yD5KEmVfamPAIzjmOk2Fm318bkJ2qON3OUKaLZiV3N4Q==",
-      "peerDependencies": {
-        "monaco-editor": "~0.34.0",
-        "vscode-oniguruma": "^1.6.2",
-        "vscode-textmate": "^7.0.1"
-      }
+      "resolved": "..",
+      "link": true
     },
     "node_modules/vscode-oniguruma": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
       "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA=="
-    },
-    "node_modules/vscode-textmate": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.1.tgz",
-      "integrity": "sha512-zQ5U/nuXAAMsh691FtV0wPz89nSkHbs+IQV8FDk+wew9BlSDhf4UmWGlWJfTR2Ti6xZv87Tj5fENzKf6Qk7aLw==",
-      "peer": true
-    }
-  },
-  "dependencies": {
-    "@esbuild/linux-loong64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
-      "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
-      "dev": true,
-      "optional": true
-    },
-    "@types/throttle-debounce": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
-      "integrity": "sha512-Pb7k35iCGFcGPECoNE4DYp3Oyf2xcTd3FbFQxXUI9hEYKUl6YX+KLf7HrBmgVcD05nl50LIH6i+80js4iYmWbw==",
-      "dev": true
-    },
-    "esbuild": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
-      "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
-      "dev": true,
-      "requires": {
-        "@esbuild/linux-loong64": "0.14.54",
-        "esbuild-android-64": "0.14.54",
-        "esbuild-android-arm64": "0.14.54",
-        "esbuild-darwin-64": "0.14.54",
-        "esbuild-darwin-arm64": "0.14.54",
-        "esbuild-freebsd-64": "0.14.54",
-        "esbuild-freebsd-arm64": "0.14.54",
-        "esbuild-linux-32": "0.14.54",
-        "esbuild-linux-64": "0.14.54",
-        "esbuild-linux-arm": "0.14.54",
-        "esbuild-linux-arm64": "0.14.54",
-        "esbuild-linux-mips64le": "0.14.54",
-        "esbuild-linux-ppc64le": "0.14.54",
-        "esbuild-linux-riscv64": "0.14.54",
-        "esbuild-linux-s390x": "0.14.54",
-        "esbuild-netbsd-64": "0.14.54",
-        "esbuild-openbsd-64": "0.14.54",
-        "esbuild-sunos-64": "0.14.54",
-        "esbuild-windows-32": "0.14.54",
-        "esbuild-windows-64": "0.14.54",
-        "esbuild-windows-arm64": "0.14.54"
-      }
-    },
-    "esbuild-android-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
-      "integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-android-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
-      "integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-darwin-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
-      "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-darwin-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
-      "integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
-      "integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
-      "integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-32": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
-      "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
-      "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
-      "integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
-      "integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-mips64le": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
-      "integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-ppc64le": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
-      "integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-riscv64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
-      "integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-s390x": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
-      "integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-netbsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
-      "integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-openbsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
-      "integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-sunos-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
-      "integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-32": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
-      "integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
-      "integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
-      "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
-      "dev": true,
-      "optional": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
-    "is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3"
-      }
-    },
-    "monaco-editor": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.0.tgz",
-      "integrity": "sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ=="
-    },
-    "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true
-    },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
-    "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
-    },
-    "postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
-      "dev": true,
-      "requires": {
-        "nanoid": "^3.3.4",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      }
-    },
-    "resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-      "dev": true,
-      "requires": {
-        "is-core-module": "^2.9.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      }
-    },
-    "rollup": {
-      "version": "2.77.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
-      "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
-      "dev": true,
-      "requires": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
-    },
-    "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
-    },
-    "throttle-debounce": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
-      "integrity": "sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg=="
-    },
-    "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true
-    },
-    "vite": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.9.tgz",
-      "integrity": "sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==",
-      "dev": true,
-      "requires": {
-        "esbuild": "^0.14.47",
-        "fsevents": "~2.3.2",
-        "postcss": "^8.4.16",
-        "resolve": "^1.22.1",
-        "rollup": ">=2.75.6 <2.77.0 || ~2.77.0"
-      }
-    },
-    "vscode": {
-      "version": "npm:@codingame/monaco-vscode-api@1.69.21",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-1.69.21.tgz",
-      "integrity": "sha512-m+oLyRchCnv++oETMPXlkrw532hVM3v83atyG/2GA6yD5KEmVfamPAIzjmOk2Fm318bkJ2qON3OUKaLZiV3N4Q==",
-      "requires": {}
-    },
-    "vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA=="
-    },
-    "vscode-textmate": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.1.tgz",
-      "integrity": "sha512-zQ5U/nuXAAMsh691FtV0wPz89nSkHbs+IQV8FDk+wew9BlSDhf4UmWGlWJfTR2Ti6xZv87Tj5fENzKf6Qk7aLw==",
-      "peer": true
     }
   }
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -4,21 +4,24 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "start": "vite"
+    "clean": "tsc -b -c",
+    "compile": "tsc",
+    "start": "vite",
+    "start:debug": "vite --debug --force"
   },
   "devDependencies": {
-    "@types/throttle-debounce": "^5.0.0",
-    "typescript": "^4.7.4",
-    "vite": "^3.0.9"
+    "@types/throttle-debounce": "~5.0.0",
+    "typescript": "~4.9.5",
+    "vite": "~4.1.4"
   },
   "dependencies": {
-    "monaco-editor": "~0.34.0",
-    "throttle-debounce": "^5.0.0",
-    "vscode": "npm:@codingame/monaco-vscode-api@~1.69.21",
+    "monaco-editor": "~0.34.1",
+    "throttle-debounce": "~5.0.0",
+    "vscode": "file:../",
     "vscode-oniguruma": "~1.6.2"
   },
   "volta": {
-    "node": "16.15.0",
-    "npm": "8.11.0"
+    "node": "18.14.2",
+    "npm": "9.5.1"
   }
 }

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -13,16 +13,15 @@ import 'monaco-editor/esm/vs/editor/standalone/browser/referenceSearch/standalon
 import 'monaco-editor/esm/vs/language/json/monaco.contribution'
 import { getUserConfiguration, onUserConfigurationChange, updateUserConfiguration } from 'vscode/service-override/configuration'
 import { updateUserKeybindings } from 'vscode/service-override/keybindings'
-import { createConfiguredEditor } from 'vscode/monaco'
-import { getJsonSchemas, onDidChangeJsonSchema } from 'vscode/monaco'
+import { createConfiguredEditor, getJsonSchemas, onDidChangeJsonSchema } from 'vscode/monaco'
 import { debounce } from 'throttle-debounce'
 import * as vscode from 'vscode'
 
-vscode.window.showInformationMessage('Hello', {
+void vscode.window.showInformationMessage('Hello', {
   detail: 'Welcome to the monaco-vscode-api demo',
   modal: true
 }).then(() => {
-  vscode.window.showInformationMessage('Try to change the settings or the configuration, the changes will be applied to all 3 editors')
+  void vscode.window.showInformationMessage('Try to change the settings or the configuration, the changes will be applied to all 3 editors')
 })
 
 createConfiguredEditor(document.getElementById('editor')!, {
@@ -55,13 +54,13 @@ const settingsModel = monaco.editor.createModel(
 createConfiguredEditor(document.getElementById('settings-editor')!, {
   model: settingsModel
 })
-settingsModel.onDidChangeContent(debounce(1000, () => {
-  updateUserConfiguration(settingsModel.getValue())
+settingsModel.onDidChangeContent(debounce(1000, async () => {
+  await updateUserConfiguration(settingsModel.getValue())
 }))
-updateUserConfiguration(settingsModel.getValue())
+void updateUserConfiguration(settingsModel.getValue())
 onUserConfigurationChange(async () => {
   const newConfiguration = await getUserConfiguration()
-  if (newConfiguration != settingsModel.getValue()) {
+  if (newConfiguration !== settingsModel.getValue()) {
     settingsModel.setValue(newConfiguration)
   }
 })
@@ -82,10 +81,10 @@ const keybidingsModel = monaco.editor.createModel(
 createConfiguredEditor(document.getElementById('keybindings-editor')!, {
   model: keybidingsModel
 })
-keybidingsModel.onDidChangeContent(debounce(1000, () => {
-  updateUserKeybindings(keybidingsModel.getValue())
+keybidingsModel.onDidChangeContent(debounce(1000, async () => {
+  await updateUserKeybindings(keybidingsModel.getValue())
 }))
-updateUserKeybindings(keybidingsModel.getValue())
+void updateUserKeybindings(keybidingsModel.getValue())
 
 function updateDiagnosticsOptions () {
   monaco.languages.json.jsonDefaults.setDiagnosticsOptions({

--- a/demo/src/setup.ts
+++ b/demo/src/setup.ts
@@ -24,98 +24,99 @@ import themes from './resources/themes/themes.json'
 
 // Workers
 interface WrappedWorker {
-	new(): Worker
+  new(): Worker
 }
 export type WorkerLoader = () => WrappedWorker | Promise<WrappedWorker>
 const workerLoaders: Partial<Record<string, WorkerLoader>> = {
-	editorWorkerService: () => EditorWorker,
-	json: () => JsonWorker
+  editorWorkerService: () => EditorWorker,
+  json: () => JsonWorker
 }
 window.MonacoEnvironment = {
-	getWorker: async function (moduleId, label) {
-		const workerFactory = workerLoaders[label]
-		if (workerFactory != null) {
-			const Worker = await workerFactory()
-			return new Worker()
-		}
-		throw new Error(`Unimplemented worker ${label} (${moduleId})`)
-	}
+  getWorker: async function (moduleId, label) {
+    const workerFactory = workerLoaders[label]
+    if (workerFactory != null) {
+      const Worker = await workerFactory()
+      return new Worker()
+    }
+    throw new Error(`Unimplemented worker ${label} (${moduleId})`)
+  }
 }
 
 // Override services
 StandaloneServices.initialize({
-	...getModelEditorServiceOverride(async (model, options) => {
-		console.log('trying to open a model', model, options)
-		return undefined
-	}),
-	...getNotificationServiceOverride(),
-	...getDialogsServiceOverride(),
-	...getConfigurationServiceOverride(),
-	...getKeybindingsServiceOverride(),
-	...getTextmateServiceOverride(async () => {
-		const response = await fetch(onigFile)
-		return await response.arrayBuffer()
-	}),
-	...getThemeServiceOverride(),
-	...geTokenClassificationServiceOverride(),
-	...getLanguageConfigurationServiceOverride(),
-	...getLanguagesServiceOverride()
+  ...getModelEditorServiceOverride(async (model, options) => {
+    // eslint-disable-next-line no-console
+    console.log('trying to open a model', model, options)
+    return undefined
+  }),
+  ...getNotificationServiceOverride(),
+  ...getDialogsServiceOverride(),
+  ...getConfigurationServiceOverride(),
+  ...getKeybindingsServiceOverride(),
+  ...getTextmateServiceOverride(async () => {
+    const response = await fetch(onigFile)
+    return await response.arrayBuffer()
+  }),
+  ...getThemeServiceOverride(),
+  ...geTokenClassificationServiceOverride(),
+  ...getLanguageConfigurationServiceOverride(),
+  ...getLanguagesServiceOverride()
 })
 
 const loader = {
-	'/themes/dark_plus.json': async () => (await import('./resources/themes/theme-defaults~dark_plus.json?raw')).default,
-	'/themes/light_plus.json': async () => (await import('./resources/themes/theme-defaults~light_plus.json?raw')).default,
-	'/themes/dark_vs.json': async () => (await import('./resources/themes/theme-defaults~dark_vs.json?raw')).default,
-	'/themes/light_vs.json': async () => (await import('./resources/themes/theme-defaults~light_vs.json?raw')).default,
-	'/themes/hc_black.json': async () => (await import('./resources/themes/theme-defaults~hc_black.json?raw')).default,
-	'/themes/hc_light.json': async () => (await import('./resources/themes/theme-defaults~hc_light.json?raw')).default
+  '/themes/dark_plus.json': async () => (await import('./resources/themes/theme-defaults~dark_plus.json?raw')).default,
+  '/themes/light_plus.json': async () => (await import('./resources/themes/theme-defaults~light_plus.json?raw')).default,
+  '/themes/dark_vs.json': async () => (await import('./resources/themes/theme-defaults~dark_vs.json?raw')).default,
+  '/themes/light_vs.json': async () => (await import('./resources/themes/theme-defaults~light_vs.json?raw')).default,
+  '/themes/hc_black.json': async () => (await import('./resources/themes/theme-defaults~hc_black.json?raw')).default,
+  '/themes/hc_light.json': async () => (await import('./resources/themes/theme-defaults~hc_light.json?raw')).default
 } as Partial<Record<string, () => Promise<string>>>
 setDefaultThemes(themes as IThemeExtensionPoint[], async (theme) => loader[theme.path.slice(1)]!())
 
 setLanguages([{
-	id: 'java',
-	extensions: [
-		'.java',
-		'.jav'
-	],
-	aliases: [
-		'Java',
-		'java'
-	],
-	configuration: `./java-configuration.json`
+  id: 'java',
+  extensions: [
+    '.java',
+    '.jav'
+  ],
+  aliases: [
+    'Java',
+    'java'
+  ],
+  configuration: './java-configuration.json'
 }, {
-	id: 'json',
-	aliases: [
-		'JSON',
-		'json'
-	],
-	extensions: [
-		'.json'
-	],
-	mimetypes: [
-		'application/json',
-		'application/manifest+json'
-	],
-	configuration: `./json-configuration.json`
+  id: 'json',
+  aliases: [
+    'JSON',
+    'json'
+  ],
+  extensions: [
+    '.json'
+  ],
+  mimetypes: [
+    'application/json',
+    'application/manifest+json'
+  ],
+  configuration: './json-configuration.json'
 }])
-setLanguageConfiguration(`/java-configuration.json`, async () => {
-	return (await import('./resources/java-language-configuration.json?raw')).default
+setLanguageConfiguration('/java-configuration.json', async () => {
+  return (await import('./resources/java-language-configuration.json?raw')).default
 })
-setLanguageConfiguration(`/json-configuration.json`, async () => {
-	return (await import('./resources/json-language-configuration.json?raw')).default
+setLanguageConfiguration('/json-configuration.json', async () => {
+  return (await import('./resources/json-language-configuration.json?raw')).default
 })
 setGrammars([{
-	language: 'java',
-	scopeName: 'source.java',
-	path: './java-grammar.json'
+  language: 'java',
+  scopeName: 'source.java',
+  path: './java-grammar.json'
 }, {
-	language: 'json',
-	scopeName: 'source.json',
-	path: './json-grammar.json'
+  language: 'json',
+  scopeName: 'source.json',
+  path: './json-grammar.json'
 }], async (grammar) => {
-	switch (grammar.language) {
-		case 'java': return (await import('./resources/java.tmLanguage.json?raw')).default
-		case 'json': return (await import('./resources/JSON.tmLanguage.json?raw')).default
-	}
-	throw new Error('grammar not found')
+  switch (grammar.language) {
+    case 'java': return (await import('./resources/java.tmLanguage.json?raw')).default
+    case 'json': return (await import('./resources/JSON.tmLanguage.json?raw')).default
+  }
+  throw new Error('grammar not found')
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,19 @@
         "vscode-textmate": "^7.0.1"
       }
     },
+    "demo": {
+      "name": "monaco-vscode-api-demo",
+      "version": "0.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "throttle-debounce": "~5.0.0",
+        "vscode": "npm:@codingame/monaco-vscode-api@*",
+        "vscode-oniguruma": "~1.7.0"
+      },
+      "devDependencies": {
+        "@types/throttle-debounce": "~5.0.0"
+      }
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -6050,9 +6063,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "version": "8.4.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
       "dev": true,
       "funding": [
         {
@@ -12347,9 +12360,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "version": "8.4.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -135,11 +135,12 @@
     "README.md"
   ],
   "scripts": {
-    "build": "rm -rf dist/ && npm run lint && npm run compile && npm run generate-types && npm run compile-webpack-loader",
+    "build": "npm run clean && npm run compile && npm run lint && npm run generate-types && npm run compile-webpack-loader",
     "compile": "rollup --config rollup/rollup.config.ts --configPlugin 'typescript={tsconfig: `tsconfig.rollup.json`}' --vscode-version ${npm_package_config_vscode_version}",
+    "clean": "rm -rf dist/",    
     "compile-webpack-loader": "tsc --target es2020 -lib es2020 --module commonjs --skipLibCheck --moduleResolution node --declaration --outDir dist src/webpack-loader.ts && mv dist/webpack-loader.js dist/webpack-loader.cjs",
     "preprepare": "./scripts/install-vscode",
-    "lint": "eslint --ext ts src",
+    "lint": "eslint {**/src/**/*.ts,./rollup/*.ts,./*.ts}",
     "generate-types": "tsc --project tsconfig.types.json && rollup --config rollup/rollup.types.config.ts --configPlugin 'typescript={tsconfig: `tsconfig.rollup.json`}' && rm -rf ./dist/types",
     "release": "node --loader ts-node/esm release.ts ${npm_package_config_vscode_version}"
   },
@@ -196,7 +197,7 @@
     }
   },
   "volta": {
-    "node": "18.13.0",
-    "npm": "9.4.1"
+    "node": "18.14.2",
+    "npm": "9.5.1"
   }
 }

--- a/rollup/rollup.config.ts
+++ b/rollup/rollup.config.ts
@@ -49,12 +49,14 @@ const PURE_FUNCTIONS = new Set([
 
 const EXTENSIONS = ['', '.ts', '.js']
 
-const SRC_DIR = path.resolve(__dirname, '../src')
-const DIST_DIR = path.resolve(__dirname, '../dist')
-const VSCODE_DIR = path.resolve(__dirname, '../vscode')
-const NODE_MODULES_DIR = path.resolve(__dirname, '../node_modules')
+const BASE_DIR = path.resolve(__dirname, '..')
+const TSCONFIG = path.resolve(BASE_DIR, 'tsconfig.json')
+const SRC_DIR = path.resolve(BASE_DIR, 'src')
+const DIST_DIR = path.resolve(BASE_DIR, 'dist')
+const VSCODE_DIR = path.resolve(BASE_DIR, 'vscode')
+const NODE_MODULES_DIR = path.resolve(BASE_DIR, 'node_modules')
 const MONACO_EDITOR_DIR = path.resolve(NODE_MODULES_DIR, './monaco-editor')
-const OVERRIDE_PATH = path.resolve(__dirname, '../src/override')
+const OVERRIDE_PATH = path.resolve(BASE_DIR, 'src/override')
 const KEYBOARD_LAYOUT_DIR = path.resolve(VSCODE_DIR, 'vs/workbench/services/keybinding/browser/keyboardLayouts')
 
 function getMemberExpressionPath (node: recast.types.namedTypes.MemberExpression | recast.types.namedTypes.Identifier): string | null {
@@ -175,6 +177,7 @@ export default (args: Record<string, string>): rollup.RollupOptions[] => {
       }),
       typescript({
         noEmitOnError: true,
+        tsconfig: TSCONFIG,
         transformers: {
           before: [{
             type: 'program',

--- a/scripts/install-vscode
+++ b/scripts/install-vscode
@@ -5,6 +5,15 @@ vscodeVersion=$(node -e "console.log(require('./node_modules/monaco-editor/packa
 
 output_directory="`pwd`/vscode"
 patch_file="`pwd`/scripts/vscode.patch"
+version_info=$output_directory/version.info
+
+if [[ -e $version_info && $(cat $version_info) == $vscodeVersion ]]; then
+    echo "vscode version $vscodeVersion is already installed. Aborting..."
+    exit 0
+else
+    echo "vscode version $vscodeVersion is not available. Installing..."
+fi
+
 rm -rf $output_directory
 
 build_directory=`mktemp -d`
@@ -24,6 +33,9 @@ cd src
 rm -rf `find . -name '*.test.ts' -o -name 'test' -o -name 'electron-browser'`
 rm -rf vs/code
 rm -rf vs/server
+
+mkdir -p $output_directory
+echo $vscodeVersion > $version_info
 
 echo "Building vscode..."
 npx tsc --declaration --importHelpers --module es2020 --preserveConstEnums --outDir "$output_directory/vs"

--- a/src/service-override/tools.ts
+++ b/src/service-override/tools.ts
@@ -1,7 +1,7 @@
 import { IMessage } from 'vs/workbench/services/extensions/common/extensions'
 import { ExtensionPoint, ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry'
 import { StandaloneServices } from 'vs/editor/standalone/browser/standaloneServices'
-import { EventEmitter } from 'vscode'
+import { Emitter } from 'vs/base/common/event'
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation'
 import { Severity } from '../services'
 
@@ -20,7 +20,7 @@ export function getExtensionPoint<T> (extensionPoint: string): ExtensionPoint<T>
   return ExtensionsRegistry.getExtensionPoints().find(ep => ep.name === extensionPoint) as ExtensionPoint<T>
 }
 
-const emitter = new EventEmitter<IInstantiationService>()
+const emitter = new Emitter<IInstantiationService>()
 export const onServicesInitialized = emitter.event
 
 // Hook StandaloneServices.initialize to instantiate required classes right after

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,15 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true,
+	},
+	"include": [
+		"**/src/**/*.ts",
+		"./rollup/*.ts",
+		"./*.ts"
+	],
+	"exclude": [
+		"./dist/**/*",
+		"./vscode/**/*"
+	]
+}


### PR DESCRIPTION
List of enhancements:

- Update demo specific dependencies
- Demo: change `monaco-vscode-api` dependency to local reference.
- `npm install` will no longer pull vscode if version info file with same version content is found. It is checked before the download starts and the file is written at the end
- vscode+eslint works now for alle code. `tsconfig.eslint.json` + eslint config changes are introduced + eslint related settings for vscode are added.