### PR TITLE
Fix webpack-loader on Windows

### DIFF
--- a/src/override/vs/editor/contrib/suggest/browser/suggest.js
+++ b/src/override/vs/editor/contrib/suggest/browser/suggest.js
@@ -14,7 +14,7 @@ It's treeshaked out of monaco editor and needs to be reintroduced.
 If you're using webpack, you can add a loader that will polyfill it:
 \`\`\`
 {
-  test: /node_modules\\/monaco-editor\\//,
+  test: /node_modules[\\/]monaco-editor/,
   loader: 'vscode/webpack-loader'
 }
 \`\`\`

--- a/src/webpack-loader.ts
+++ b/src/webpack-loader.ts
@@ -1,7 +1,8 @@
 import type { RawLoaderDefinitionFunction } from 'webpack'
+import { sep as s } from 'path'
 
 const monacoPolyfillLoader: RawLoaderDefinitionFunction = function (source) {
-  if (this.resourcePath.endsWith('monaco-editor/esm/vs/editor/contrib/suggest/browser/suggest.js')) {
+  if (this.resourcePath.endsWith(`monaco-editor${s}esm${s}vs${s}editor${s}contrib${s}suggest${s}browser${s}suggest.js`)) {
     return `${source.toString()}
 export function setSnippetSuggestSupport(support) {
   const old = _snippetSuggestSupport;


### PR DESCRIPTION
Btw:
```javascript
test: /node_modules[\\/]monaco-editor/
```

Can also be this X-Platform out of the box:
```javascript
path.resolve(__dirname, 'node_modules', 'monaco-editor')
```