### PR TITLE
Don't apply treemending patch if file hashes match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules/
 vscode/
 vscode-default-extensions/
 dist/
-monaco-editor-treemending.patch
-monaco-editor-hashes.txt
+monaco-editor-treemending.*

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vscode/
 vscode-default-extensions/
 dist/
 monaco-editor-treemending.patch
+monaco-editor-hashes.txt

--- a/package.json
+++ b/package.json
@@ -157,8 +157,7 @@
   "files": [
     "dist",
     "monaco-treemending.js",
-    "monaco-editor-treemending.patch",
-    "monaco-editor-hashes.txt",
+    "monaco-editor-treemending.*",
     "README.md"
   ],
   "scripts": {
@@ -172,7 +171,7 @@
     "generate-types": "tsc --project tsconfig.types.json && rollup --config rollup/rollup.types.config.ts --configPlugin 'typescript={tsconfig: `tsconfig.rollup-config-types.json`}' && rm -rf ./dist/types",
     "release": "node --loader ts-node/esm release.ts ${npm_package_config_vscode_version}",
     "reset:repo": "git clean -f -X -d",
-    "gen:hash:module": "node --loader ts-node/esm src/monaco-calc-hashes.ts node_modules/monaco-editor/esm monaco-editor-hashes-module.txt"
+    "gen:hash:module": "node --loader ts-node/esm src/monaco-calc-hashes.ts --script node_modules/monaco-editor/esm monaco-editor-treemending.sh256test"
   },
   "bin": {
     "monaco-treemending": "./monaco-treemending.js"

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "dist",
     "monaco-treemending.js",
     "monaco-editor-treemending.patch",
+    "monaco-editor-hashes.txt",
     "README.md"
   ],
   "scripts": {
@@ -170,7 +171,8 @@
     "lint": "eslint {/src/**/*.ts,./rollup/*.ts,./*.ts}",
     "generate-types": "tsc --project tsconfig.types.json && rollup --config rollup/rollup.types.config.ts --configPlugin 'typescript={tsconfig: `tsconfig.rollup-config-types.json`}' && rm -rf ./dist/types",
     "release": "node --loader ts-node/esm release.ts ${npm_package_config_vscode_version}",
-    "reset:repo": "git clean -f -X -d"
+    "reset:repo": "git clean -f -X -d",
+    "gen:hash:module": "node --loader ts-node/esm src/monaco-calc-hashes.ts node_modules/monaco-editor/esm monaco-editor-hashes-module.txt"
   },
   "bin": {
     "monaco-treemending": "./monaco-treemending.js"

--- a/scripts/create-treemending-patch.sh
+++ b/scripts/create-treemending-patch.sh
@@ -32,6 +32,6 @@ diff -urN -x '*.map' a b > "$editor_patch_file" || true
 cd ..
 
 cd $dir_base
-node --loader ts-node/esm $dir_base/src/monaco-calc-hashes.ts $build_directory/editor-patch/b $dir_base/monaco-editor-hashes.txt
+node --loader ts-node/esm $dir_base/src/monaco-calc-hashes.ts --script $build_directory/editor-patch/b $dir_base/monaco-editor-treemending.sha256
 
 echo "Completed treemending process"

--- a/scripts/create-treemending-patch.sh
+++ b/scripts/create-treemending-patch.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+dir_me=$(realpath $(dirname $0))
+dir_base=$(realpath $dir_me/..)
+
+build_directory=$1
+monaco_esm_directory=${dir_base}/node_modules/monaco-editor/esm
+editor_patch_file=${dir_base}/monaco-editor-treemending.patch
+
+echo "Starting treemending process"
+
+cd $build_directory
+
+# build editor without treeshaking to generate the treemending patch
+echo "Installing build dependencies"
+which node
+cd build
+yarn install --ignore-engines
+cd ..
+
+mkdir -p editor-patch
+cp -R $monaco_esm_directory editor-patch/a
+cp -R $monaco_esm_directory editor-patch/b
+## Change shake level from ClassMembers to Files
+sed -i 's/shakeLevel: 2/shakeLevel: 0/g' build/gulpfile.editor.js
+npx gulp editor-distro
+cd out-monaco-editor-core/esm/
+cp --parents $(find -name \*.js) ../../editor-patch/b
+cd ../../editor-patch
+diff -urN -x '*.map' a b > "$editor_patch_file" || true 
+cd ..
+
+cd $dir_base
+node --loader ts-node/esm $dir_base/src/monaco-calc-hashes.ts $build_directory/editor-patch/b $dir_base/monaco-editor-hashes.txt
+
+echo "Completed treemending process"

--- a/scripts/install-vscode
+++ b/scripts/install-vscode
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+dir_me=$(realpath $(dirname $0))
+dir_base=$(realpath $dir_me/..)
+
 vscodeRef=$(cat './node_modules/monaco-editor/package.json' | jq -r '.["vscodeRef"]')
 
 monaco_esm_directory="`pwd`/node_modules/monaco-editor/esm"
@@ -34,25 +37,7 @@ yarn install --ignore-scripts
 echo "Patching vscode..."
 patch -p1 < $patch_file
 
-# build editor without treeshaking to generate the treemending patch
-echo "Installing build dependencies"
-which node
-cd build
-yarn install --ignore-engines
-cd ..
-
-mkdir -p editor-patch
-cp -R $monaco_esm_directory editor-patch/a
-cp -R $monaco_esm_directory editor-patch/b
-## Change shake level from ClassMembers to Files
-sed -i 's/shakeLevel: 2/shakeLevel: 0/g' build/gulpfile.editor.js
-npx gulp editor-distro
-cd out-monaco-editor-core/esm/
-cp --parents $(find -name \*.js) ../../editor-patch/b
-cd ../../editor-patch
-diff -urN -x '*.map' a b > "$editor_patch_file" || true 
-cd ..
-# end treemending patch
+bash ${dir_me}/create-treemending-patch.sh $build_directory
 
 # copy default extensions
 rm -rf $extension_output_directory

--- a/src/monaco-calc-hashes.ts
+++ b/src/monaco-calc-hashes.ts
@@ -1,0 +1,54 @@
+import * as os from 'os'
+import { readdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { normalize, resolve } from 'path'
+import { createHash } from 'node:crypto'
+
+const walk = async (basePath: string, dirPath: string) => {
+  const entries = await readdir(dirPath, {
+    encoding: 'binary',
+    withFileTypes: true
+  })
+  let hashes: string[] = []
+  for (const entry of entries) {
+    const childPath = join(dirPath, entry.name)
+    if (entry.isDirectory()) {
+      const res = await walk(basePath, childPath)
+      hashes = [...hashes, ...res]
+    } else {
+      const content = await readFile(childPath)
+      const output = `{ path: ${childPath.replace(basePath, '')}, hash: ${createHash('sha3-256').update(content).digest('hex')} }`
+      hashes.push(output)
+    }
+  }
+  return hashes
+}
+
+export const calcModuleHash = async (basePath: string, writeOutput: boolean, outputFile?: string): Promise<string> => {
+  const res = await walk(basePath, basePath)
+  const joined = res.join(os.EOL)
+  if (writeOutput && outputFile != null) {
+    await writeFile(outputFile, joined)
+  }
+  return joined
+}
+
+// work as script
+const dirIn = process.argv[2]
+const outputFileIn = process.argv[3]
+
+if (dirIn != null && outputFileIn != null) {
+  const dir = resolve(normalize(dirIn))
+  const outputFile = resolve(normalize(outputFileIn))
+
+  const run = async () => {
+    await calcModuleHash(dir, true, outputFile)
+  }
+
+  run().then(() => {
+    // eslint-disable-next-line no-console
+    console.info('Monaco-editor hashes were successfully created here: ' + outputFile)
+  }, err => {
+    console.error(err)
+  })
+}

--- a/src/monaco-calc-hashes.ts
+++ b/src/monaco-calc-hashes.ts
@@ -27,28 +27,32 @@ const walk = async (basePath: string, dirPath: string) => {
 export const calcModuleHash = async (basePath: string, writeOutput: boolean, outputFile?: string): Promise<string> => {
   const res = await walk(basePath, basePath)
   const joined = res.join(os.EOL)
+  const joinedHash = createHash('sha3-256').update(joined).digest('hex')
   if (writeOutput && outputFile != null) {
-    await writeFile(outputFile, joined)
+    await writeFile(outputFile, joinedHash)
   }
   return joined
 }
 
 // work as script
-const dirIn = process.argv[2]
-const outputFileIn = process.argv[3]
+const script = process.argv[2]
+if (script === '--script') {
+  const dirIn = process.argv[3]
+  const outputFileIn = process.argv[4]
 
-if (dirIn != null && outputFileIn != null) {
-  const dir = resolve(normalize(dirIn))
-  const outputFile = resolve(normalize(outputFileIn))
+  if (dirIn != null && outputFileIn != null) {
+    const dir = resolve(normalize(dirIn))
+    const outputFile = resolve(normalize(outputFileIn))
 
-  const run = async () => {
-    await calcModuleHash(dir, true, outputFile)
+    const run = async () => {
+      await calcModuleHash(dir, true, outputFile)
+    }
+
+    run().then(() => {
+      // eslint-disable-next-line no-console
+      console.info('Monaco-editor hashes were successfully created here: ' + outputFile)
+    }, err => {
+      console.error(err)
+    })
   }
-
-  run().then(() => {
-    // eslint-disable-next-line no-console
-    console.info('Monaco-editor hashes were successfully created here: ' + outputFile)
-  }, err => {
-    console.error(err)
-  })
 }

--- a/src/monaco-treemending.ts
+++ b/src/monaco-treemending.ts
@@ -2,18 +2,24 @@ import { applyPatches, ParsedDiff } from 'diff'
 import * as fs from 'fs/promises'
 import * as path from 'path'
 import { createRequire } from 'node:module'
+import { calcModuleHash } from './monaco-calc-hashes.js'
 const require = createRequire(import.meta.url)
 
 async function run () {
   const patchContent = await fs.readFile(require.resolve('../monaco-editor-treemending.patch'))
+  const refMonacoHashes = (await fs.readFile(require.resolve('../monaco-editor-hashes.txt'))).toString()
 
   const monacoDirectory = path.resolve(path.dirname(require.resolve('monaco-editor/monaco.d.ts', { paths: [process.cwd()] })), 'esm')
+  const monacoHashes = await calcModuleHash(monacoDirectory, false)
+  if (monacoHashes === refMonacoHashes) {
+    return Promise.resolve('Monaco-editor was already tree-mended. All esm files hashes match!')
+  }
 
   function getMonacoFile (diff: ParsedDiff) {
     return path.resolve(monacoDirectory, diff.oldFileName!.slice('a/'.length))
   }
 
-  await new Promise<void>((resolve, reject) => {
+  const result = await new Promise<void | string>((resolve, reject) => {
     applyPatches(patchContent.toString('utf-8'), {
       loadFile: async function (index: ParsedDiff, callback: (err: unknown, data: string) => void): Promise<void> {
         try {
@@ -41,16 +47,17 @@ async function run () {
         if (err != null) {
           reject(err)
         } else {
-          resolve()
+          resolve('Monaco-editor was tree-mended')
         }
       }
     })
   })
+  return result
 }
 
-run().then(() => {
+run().then((s) => {
   // eslint-disable-next-line no-console
-  console.info('Monaco-editor was tree-mended')
+  console.info(s)
 }, err => {
   console.error(err)
 })

--- a/src/monaco-treemending.ts
+++ b/src/monaco-treemending.ts
@@ -7,7 +7,7 @@ const require = createRequire(import.meta.url)
 
 async function run () {
   const patchContent = await fs.readFile(require.resolve('../monaco-editor-treemending.patch'))
-  const refMonacoHashes = (await fs.readFile(require.resolve('../monaco-editor-hashes.txt'))).toString()
+  const refMonacoHashes = (await fs.readFile(require.resolve('../monaco-editor-treemending.sha256'))).toString()
 
   const monacoDirectory = path.resolve(path.dirname(require.resolve('monaco-editor/monaco.d.ts', { paths: [process.cwd()] })), 'esm')
   const monacoHashes = await calcModuleHash(monacoDirectory, false)


### PR DESCRIPTION
After treemending patch creation a file including names and hashes of all files of the esm folder is created (expectation).
This expectation file is added to the `monaco-vscode-api` package.
When `monaco-treemending` is executed it performs the same calculation on the installed monaco-editor esm files and successfully terminates early if the file hashes meet the expectation.

This should fix https://github.com/TypeFox/monaco-languageclient/issues/491 and #113 , but a test with pnpm is still outstanding