### PR TITLE
Do not provide blob urls to json worker

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -113,7 +113,7 @@ FileAccess.uriToBrowserUri = function (uri: URI) {
 
 export function registerExtension (manifest: IExtensionManifest, defaultNLS?: ITranslations): RegisterExtensionResult {
   const uuid = generateUuid()
-  const location = URI.from({ scheme: 'extension', path: `/${uuid}` })
+  const location = URI.from({ scheme: 'extension', authority: uuid, path: '/' })
 
   const localizedManifest = defaultNLS != null ? localizeManifest(manifest, defaultNLS) : manifest
 

--- a/src/json.ts
+++ b/src/json.ts
@@ -5,6 +5,7 @@ import { IUserDataProfilesService } from 'vs/platform/userDataProfile/common/use
 import { IJSONContributionRegistry, Extensions as JsonExtensions } from 'vs/platform/jsonschemas/common/jsonContributionRegistry'
 import { Emitter, Event } from 'vs/base/common/event'
 import { FileAccess } from 'vs/base/common/network'
+import { parse } from 'vs/base/common/json'
 import * as vscode from './api'
 
 type Unpacked<T> = T extends (infer U)[] ? U : T
@@ -23,22 +24,29 @@ function getDefaultSchemaAssociations (): JsonSchema[] {
   }]
 }
 
-function getExtensionSchemaAssociations (): JsonSchema[] {
-  const associations: JsonSchema[] = []
-  vscode.extensions.all.forEach(extension => {
+async function getExtensionSchemaAssociations (): Promise<JsonSchema[]> {
+  const associations: JsonSchema[] = (await Promise.all(vscode.extensions.all.map(async extension => {
     const packageJSON = extension.packageJSON
     const jsonValidation = packageJSON?.contributes?.jsonValidation
     if (jsonValidation != null) {
       if (Array.isArray(jsonValidation)) {
-        jsonValidation.forEach(jv => {
+        return (await Promise.all(jsonValidation.map(async jv => {
           let { fileMatch, url }: { fileMatch: string | string[], url: string } = jv
           if (typeof fileMatch === 'string') {
             fileMatch = [fileMatch]
           }
           if (Array.isArray(fileMatch) && typeof url === 'string') {
             let uri: string = url
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            let schema: any = null
             if (uri[0] === '.' && uri[1] === '/') {
               uri = FileAccess.uriToBrowserUri(monaco.Uri.joinPath(extension.extensionUri, uri)).toString()
+            }
+            if (uri.startsWith('blob:')) {
+              // monaco json worker doesn't like blob uri, and we already have the data so let's provide it directly
+              schema = parse(await (await fetch(decodeURIComponent(uri))).text())
+              // go back to original url or the worker will try to resolve the blob url as a relative path
+              uri = monaco.Uri.joinPath(extension.extensionUri, url).toString()
             }
             fileMatch = fileMatch.map(fm => {
               if (fm[0] === '%') {
@@ -50,12 +58,14 @@ function getExtensionSchemaAssociations (): JsonSchema[] {
               }
               return fm
             })
-            associations.push({ fileMatch, uri })
+            return [<JsonSchema>{ fileMatch, uri, schema }]
           }
-        })
+          return []
+        }))).flat()
       }
     }
-  })
+    return []
+  }))).flat()
   return associations
 }
 
@@ -87,19 +97,19 @@ function registerJsonSchema (schema: JsonSchema): monaco.IDisposable {
  * Synchronize registered json schema on the monaco json worker
  */
 function synchronizeJsonSchemas (): monaco.IDisposable {
-  function updateDiagnosticsOptions () {
+  async function updateDiagnosticsOptions () {
     monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
       ...monaco.languages.json.jsonDefaults.diagnosticsOptions,
       enableSchemaRequest: true,
       schemas: [
         ...getJsonSchemas(),
         ...getDefaultSchemaAssociations(),
-        ...getExtensionSchemaAssociations()
+        ...(await getExtensionSchemaAssociations())
       ]
     })
   }
 
-  updateDiagnosticsOptions()
+  void updateDiagnosticsOptions()
   const changeEvent = Event.any<unknown>(vscode.extensions.onDidChange as Event<void>, customSchemaChangeEmitter.event, registry.onDidChangeSchema)
 
   return changeEvent(updateDiagnosticsOptions)


### PR DESCRIPTION
It fails when there is multiple schemas for the same association, the worker merges them by creating a  `allOf` parent schema that fails with blob url because it tries to resolve them as paths

I got headaches on this one