### PR TITLE
feat: add ability to register file getter for local process extensions

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -31,6 +31,7 @@ interface RegisterExtensionResult {
 interface RegisterLocalProcessExtensionResult extends RegisterExtensionResult {
   getApi (): Promise<typeof vscode>
   setAsDefaultApi (): Promise<void>
+  registerFileGetter: (path: string, getter: () => Promise<Uint8Array>) => IDisposable
 }
 
 function registerExtensionFileUrl (extensionLocation: URI, filePath: string, url: string, mimeType?: string): IDisposable {
@@ -116,6 +117,9 @@ export function registerExtension (manifest: IExtensionManifest, extHostKind?: E
       getApi,
       async setAsDefaultApi () {
         setDefaultApi(await getApi())
+      },
+      registerFileGetter (path, getter) {
+        return registerExtensionFile(extension.location, path, getter)
       }
     }
   }


### PR DESCRIPTION
Adds a new `registerFileGetter` function in the `RegisterLocalProcessExtensionResult`.

In my use case I'm bundling custom theme json within the app code and adding local process extension for that, so making it a separate file in the built app is rather an overkill.

In `~1.76.0` I was using the `registerSyncFile` in an object returned by `registerExtension`, but now we've transitioned to different extension hosts, so I understand the need in API change, just that for local process exthost this new API function should not be a problem.