### PR TITLE
fix eslint path in package.json scripts (broke compile script)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "compile-treemending-script": "rollup --config rollup/rollup.treemending-script.config.ts --configPlugin 'typescript={tsconfig: `tsconfig.rollup-config-treemending-script.json`, include: [`./rollup/rollup.treemending-script.config.ts`, `./rollup/rollup-metadata-plugin.ts`]}'",
     "compile-rollup-plugins": "rollup --config rollup/rollup.rollup-plugins.config.ts --configPlugin 'typescript={tsconfig: `tsconfig.rollup-config-plugins.json`, include: [`./rollup/rollup.rollup-plugins.config.ts`, `./rollup/rollup-metadata-plugin.ts`]}'",
     "preprepare": "./scripts/install-vscode && node --loader ts-node/esm src/monaco-treemending.ts && patch-package",
-    "lint": "eslint {/src/**/*.ts,./rollup/*.ts,./*.ts}",
+    "lint": "eslint {./src/**/*.ts,./rollup/*.ts,./*.ts}",
     "generate-types": "./scripts/generate-types",
     "release": "node --loader ts-node/esm release.ts ${npm_package_config_vscode_version}",
     "releaseNext": "node --loader ts-node/esm releaseNext.ts ${npm_package_config_vscode_version}",


### PR DESCRIPTION
So this has bothered me for a few past revs lol. 

I do not know why it hasn't bothered anyone else. It could be because of their OS, eslint version. Or how they are setup and their current $PWD, symlinks, volume bind mount, containers, etc...

But the `npm run lint` has never seemed to work properly with the absolute root path of `/src/**`. 

Since the other paths for eslint specified; `rollup` and `.` , are relative paths, I assumed it would be acceptable for the `src` as well. 

It should still be compatible with other OS's and eslint versions.

However not neccessarily compatible with setups using pecific symlinks, bind mounts, $PWD, bind mounts.

![image](https://github.com/CodinGame/monaco-vscode-api/assets/1828125/85af0429-ef54-49e6-ba4b-60cb1c69a863)

It may be somewhat petty, but it's nice when a `npm run compile` can complete and I don't have to press anything else.