### PR TITLE
Better split service overrides

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -9,8 +9,8 @@
     "compile": "tsc",
     "start": "NODE_OPTIONS=--experimental-import-meta-resolve vite --config vite.config.ts",
     "start:debug": "vite --config vite.config.ts --debug --force",
-    "build": "vite --config vite.config.ts build",
-    "build:github": "vite --config vite.github-page.config.ts build && touch dist/.nojekyll",
+    "build": "tsc --noEmit && vite --config vite.config.ts build",
+    "build:github": "tsc --noEmit && vite --config vite.github-page.config.ts build && touch dist/.nojekyll",
     "start:debugServer": "node --loader ts-node/esm src/debugServer.ts",
     "start:extHostServer": "vscode-ext-host-server --without-connection-token"
   },

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -16,6 +16,7 @@
     "noImplicitReturns": true,
     "baseUrl": ".",
     "paths": {
+      "vscode/vscode/*": ["../dist/main/vscode/src/*"],
       "vscode/*": ["../dist/main/*"]
     }
   },

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -71,8 +71,7 @@ export default defineConfig({
       '@codingame/monaco-vscode-typescript-language-features-default-extension', '@codingame/monaco-vscode-markdown-language-features-default-extension',
       '@codingame/monaco-vscode-json-language-features-default-extension', '@codingame/monaco-vscode-css-language-features-default-extension',
       '@codingame/monaco-vscode-npm-default-extension', '@codingame/monaco-vscode-css-default-extension', '@codingame/monaco-vscode-markdown-basics-default-extension', '@codingame/monaco-vscode-html-default-extension',
-      '@codingame/monaco-vscode-html-language-features-default-extension', '@codingame/monaco-vscode-configuration-editing-default-extension', '@codingame/monaco-vscode-media-preview-default-extension', '@codingame/monaco-vscode-markdown-math-default-extension',
-      'vscode/workers/textmate.worker'
+      '@codingame/monaco-vscode-html-language-features-default-extension', '@codingame/monaco-vscode-configuration-editing-default-extension', '@codingame/monaco-vscode-media-preview-default-extension', '@codingame/monaco-vscode-markdown-math-default-extension'
     ],
     esbuildOptions: {
       plugins: [{

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@types/yauzl": "^2.10.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
+        "@typescript/vfs": "^1.5.0",
         "@vscode/iconv-lite-umd": "^0.7.0",
         "@web/rollup-plugin-import-meta-assets": "^2.1.0",
         "change-package-name": "^1.0.5",
@@ -3062,6 +3063,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript/vfs": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.5.0.tgz",
+      "integrity": "sha512-AJS307bPgbsZZ9ggCT3wwpg3VbTKMFNHfaY/uF0ahSkYYrPF2dSSKDNIDIQAHm9qJqbLvCsSJH7yN4Vs/CsMMg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1"
       }
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "type": "module",
   "scripts": {
-    "build": "npm run clean && npm run generate-types && npm run lint && npm run compile-rollup-plugins && npm run compile-treemending-script && npm run compile && npm run compile-server && npm run compile-default-extensions && npm run copy-monaco-editor",
+    "build": "npm run clean && npm run lint && npm run compile && npm run compile-rollup-plugins && npm run generate-types && npm run compile-treemending-script && npm run compile-server && npm run compile-default-extensions && npm run copy-monaco-editor",
     "compile": "NODE_OPTIONS=--max_old_space_size=8192 rollup --config rollup/rollup.config.ts --configPlugin 'typescript={tsconfig: `tsconfig.rollup-config.json`}' --vscode-version ${npm_package_config_vscode_version} --vscode-ref ${npm_package_config_vscode_ref}",
     "compile-default-extensions": "NODE_OPTIONS=--max_old_space_size=8192 rollup --config rollup/rollup.default-extensions.ts --configPlugin 'typescript={tsconfig: `tsconfig.rollup-config-default-extensions.json`}'",
     "clean": "rm -rf dist/",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/yauzl": "^2.10.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
+    "@typescript/vfs": "^1.5.0",
     "@vscode/iconv-lite-umd": "^0.7.0",
     "@web/rollup-plugin-import-meta-assets": "^2.1.0",
     "change-package-name": "^1.0.5",

--- a/rollup/rollup-metadata-plugin.ts
+++ b/rollup/rollup-metadata-plugin.ts
@@ -20,12 +20,12 @@ export default ({ handle, getGroup = () => 'main', stage = 'generateBundle' }: O
   [stage]: async function (this: PluginContext, options: OutputOptions, bundle: OutputBundle) {
     const dependencyCache = new Map<string, { externals: Set<string>, internals: Set<string> }>()
 
-    const inputToOutput = Object.fromEntries(Object.values(bundle).filter((chunk): chunk is OutputChunk => (chunk as OutputChunk).code != null).map(chunk => {
-      return [
+    const inputToOutput = Object.fromEntries(Object.values(bundle)
+      .filter((chunk): chunk is OutputChunk => 'code' in chunk)
+      .map(chunk => [
         chunk.facadeModuleId,
         path.resolve(options.dir!, chunk.preliminaryFileName)
-      ]
-    }))
+      ]))
     const getModuleDependencies = (id: string, path: string[]): { externals: Set<string>, internals: Set<string> } => {
       if (path.includes(id)) {
         // Break recursive imports

--- a/rollup/rollup-metadata-plugin.ts
+++ b/rollup/rollup-metadata-plugin.ts
@@ -1,33 +1,59 @@
-import type { OutputBundle, OutputOptions, Plugin, PluginContext } from 'rollup'
+import type { OutputBundle, OutputChunk, OutputOptions, Plugin, PluginContext } from 'rollup'
 import { builtinModules } from 'module'
+import path from 'path'
 
 interface Group {
   name: string
   dependencies: Set<string>
+  modules: Set<string>
   entrypoints: Set<string>
 }
 
 interface Options {
+  stage?: 'generateBundle' | 'writeBundle'
   getGroup?: (entryPoint: string, options: OutputOptions) => string
-  handle (this: PluginContext, groupName: string, dependencies: Set<string>, entrypoints: Set<string>, options: OutputOptions, bundle: OutputBundle): void | Promise<void>
+  handle (this: PluginContext, groupName: string, dependencies: Set<string>, entrypoints: Set<string>, exclusiveModules: Set<string>, options: OutputOptions, bundle: OutputBundle): void | Promise<void>
 }
 
-export default ({ handle, getGroup = () => 'main' }: Options): Plugin => ({
+export default ({ handle, getGroup = () => 'main', stage = 'generateBundle' }: Options): Plugin => ({
   name: 'generate-metadata',
-  async generateBundle (options: OutputOptions, bundle: OutputBundle) {
-    const externalDependencyCache = new Map<string, Set<string>>()
-    const getModuleExternalDependencies = (id: string, path: string[]): Set<string> => {
-      if (!externalDependencyCache.has(id)) {
+  [stage]: async function (this: PluginContext, options: OutputOptions, bundle: OutputBundle) {
+    const dependencyCache = new Map<string, { externals: Set<string>, internals: Set<string> }>()
+
+    const inputToOutput = Object.fromEntries(Object.values(bundle).filter((chunk): chunk is OutputChunk => (chunk as OutputChunk).code != null).map(chunk => {
+      return [
+        chunk.facadeModuleId,
+        path.resolve(options.dir!, chunk.preliminaryFileName)
+      ]
+    }))
+    const getModuleDependencies = (id: string, path: string[]): { externals: Set<string>, internals: Set<string> } => {
+      if (path.includes(id)) {
+        // Break recursive imports
+        return {
+          externals: new Set(),
+          internals: new Set()
+        }
+      }
+      if (!dependencyCache.has(id)) {
         const moduleInfo = this.getModuleInfo(id)!
         if (moduleInfo.isExternal) {
           const match = /^(?:@[^/]*\/)?[^/]*/.exec(id)
-          externalDependencyCache.set(id, new Set(match != null && !builtinModules.includes(match[0]) ? [match[0]] : []))
+          dependencyCache.set(id, {
+            externals: new Set(match != null && !builtinModules.includes(match[0]) ? [match[0]] : []),
+            internals: new Set([])
+          })
         } else {
-          externalDependencyCache.set(id, new Set([...moduleInfo.importedIds, ...moduleInfo.dynamicallyImportedIds].flatMap(depId => Array.from(getModuleExternalDependencies(depId, [...path, id])))))
+          const dependencies = [...moduleInfo.importedIds, ...moduleInfo.dynamicallyImportedIds].map(depId => {
+            return getModuleDependencies(depId, [...path, id])
+          })
+          dependencyCache.set(id, {
+            externals: new Set(dependencies.map(t => t.externals).flatMap(map => Array.from(map))),
+            internals: new Set([inputToOutput[id] ?? id, ...dependencies.map(t => t.internals).flatMap(map => Array.from(map))])
+          })
         }
       }
 
-      return externalDependencyCache.get(id)!
+      return dependencyCache.get(id)!
     }
 
     const groups = new Map<string, Group>()
@@ -37,22 +63,32 @@ export default ({ handle, getGroup = () => 'main' }: Options): Plugin => ({
         continue
       }
       const groupName = getGroup(id, options)
-      const externalDependencies = getModuleExternalDependencies(moduleInfo.id, [])
+      const dependencies = getModuleDependencies(moduleInfo.id, [])
 
       if (!groups.has(groupName)) {
         groups.set(groupName, {
           dependencies: new Set<string>(),
           entrypoints: new Set<string>(),
-          name: groupName
+          name: groupName,
+          modules: new Set<string>()
         })
       }
       const group = groups.get(groupName)!
-      externalDependencies.forEach(d => group.dependencies.add(d))
+      dependencies.externals.forEach(d => group.dependencies.add(d))
+      dependencies.internals.forEach(d => group.modules.add(d))
       group.entrypoints.add(id)
     }
 
+    const moduleUseCount = new Map<string, number>()
+    for (const [_, group] of groups.entries()) {
+      for (const module of group.modules) {
+        moduleUseCount.set(module, (moduleUseCount.get(module) ?? 0) + 1)
+      }
+    }
+
     await Promise.all(Array.from(groups.entries()).map(async ([name, group]) => {
-      await handle.call(this, name, group.dependencies, group.entrypoints, options, bundle)
+      const exclusiveModules = new Set(Array.from(group.modules).filter(module => moduleUseCount.get(module)! <= 1))
+      await handle.call(this, name, group.dependencies, exclusiveModules, group.entrypoints, options, bundle)
     }))
   }
 })

--- a/rollup/rollup.config.ts
+++ b/rollup/rollup.config.ts
@@ -836,7 +836,7 @@ export default (args: Record<string, string>): rollup.RollupOptions[] => {
         }
         return 'main'
       },
-      async handle (groupName, dependencies, entrypoints, options) {
+      async handle (groupName, dependencies, exclusiveModules, entrypoints, options, bundle) {
         if (groupName === 'main') {
           // Generate package.json
           const packageJson: PackageJson = {

--- a/rollup/rollup.default-extensions.ts
+++ b/rollup/rollup.default-extensions.ts
@@ -113,7 +113,7 @@ export default rollup.defineConfig([
         }
       }),
       metadataPlugin({
-        handle (_, dependencies, entrypoints, options, bundle) {
+        handle (_, dependencies, entrypoints, exclusiveModules, options, bundle) {
           const entrypoint = Object.values(bundle).filter(v => (v as rollup.OutputChunk).isEntry)[0]!.fileName
           const packageJson: PackageJson = {
             name: `@codingame/monaco-vscode-${name}-default-extension`,
@@ -182,7 +182,7 @@ ${extensions.map(name => `  whenReady${pascalCase(name)}()`).join(',\n')}
       }
     },
     metadataPlugin({
-      handle (_, dependencies, entrypoints, options, bundle) {
+      handle (_, dependencies, entrypoints, exclusiveModules, options, bundle) {
         const entrypoint = Object.values(bundle).filter(v => (v as rollup.OutputChunk).isEntry)[0]!.fileName
         const packageJson: PackageJson = {
           name,

--- a/rollup/rollup.types.config.ts
+++ b/rollup/rollup.types.config.ts
@@ -1,9 +1,12 @@
 import * as rollup from 'rollup'
 import dts from 'rollup-plugin-dts'
 import * as tsMorph from 'ts-morph'
+import { paramCase } from 'param-case'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
 import * as fs from 'fs'
+import * as fsPromise from 'fs/promises'
+import metadataPlugin from './rollup-metadata-plugin'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -17,6 +20,11 @@ const project = new tsMorph.Project({
 const VSCODE_DIR = path.join(__dirname, '../vscode')
 const VSCODE_SRC_DIR = path.join(VSCODE_DIR, 'src')
 const DIST_DIR = path.join(__dirname, '../dist')
+const DIST_DIR_MAIN = path.resolve(DIST_DIR, 'main')
+const DIST_DIR_VSCODE_SRC_MAIN = path.resolve(DIST_DIR_MAIN, 'vscode/src')
+const TYPES_SRC_DIR = path.join(DIST_DIR, 'types/src')
+const SERVICE_OVERRIDE_DIR = path.join(TYPES_SRC_DIR, 'service-override')
+const SERVICE_OVERRIDE_DIST_DIR = path.join(DIST_DIR_MAIN, 'service-override')
 
 const interfaceOverride = new Map<string, string>()
 interfaceOverride.set('Event<T>', 'vscode.Event<T>')
@@ -31,55 +39,154 @@ interfaceOverride.set('IStandaloneDiffEditor', 'monaco.editor.IStandaloneDiffEdi
 interfaceOverride.set('IStandaloneEditorConstructionOptions', 'monaco.editor.IStandaloneEditorConstructionOptions')
 interfaceOverride.set('IStandaloneDiffEditorConstructionOptions', 'monaco.editor.IStandaloneDiffEditorConstructionOptions')
 
-export default rollup.defineConfig([{
-  input: [
-    './dist/types/src/services.d.ts',
-    './dist/types/src/extensions.d.ts',
-    ...fs.readdirSync(path.resolve(DIST_DIR, 'types/src/service-override'), { withFileTypes: true })
+function isExternal (id: string, main: boolean) {
+  if (id.endsWith('.css')) {
+    return true
+  }
+  if (id.includes('.contribution')) {
+    return true
+  }
+
+  return [
+    'vscode', 'monaco-editor', 'tas-client-umd', 'vscode-textmate', 'rollup', '@rollup/pluginutils',
+    'xterm', 'xterm-addon-canvas', 'xterm-addon-search', 'xterm-addon-unicode11',
+    'xterm-addon-webgl', 'xterm-addon-serialize', 'xterm-addon-image', 'xterm-headless'
+  ].some(external => id === external || id.startsWith(`${external}/`))
+}
+
+export default rollup.defineConfig((<{input: Record<string, string>, output: string, preserveModulesRoot?: string, main?: boolean}[]>[{
+  input: {
+    'services.d': './dist/types/src/services.d.ts',
+    'extensions.d': './dist/types/src/extensions.d.ts',
+    'monaco.d': './dist/types/src/monaco.d.ts',
+    ...Object.fromEntries(fs.readdirSync(path.resolve(DIST_DIR, 'types/src/service-override'), { withFileTypes: true })
       .filter(f => f.isFile())
       .map(f => f.name)
-      .map(name => `./dist/types/src/service-override/${name}`),
-    './dist/types/src/monaco.d.ts'
-  ],
-  output: 'dist/main'
+      .map(name => [
+          `service-override/${path.basename(name, '.ts')}`, `./dist/types/src/service-override/${name}`
+      ]))
+  },
+  output: 'dist/main',
+  main: true
 }, {
-  input: [
-    './dist/types/src/rollup-vsix-plugin.d.ts'
-  ],
+  input: {
+    'rollup-vsix-plugin.d': './dist/types/src/rollup-vsix-plugin.d.ts'
+  },
   output: 'dist/rollup-vsix-plugin'
 }, {
-  input: [
-    './dist/types/src/rollup-extension-directory-plugin.d.ts'
-  ],
+  input: {
+    'rollup-extension-directory-plugin.d': './dist/types/src/rollup-extension-directory-plugin.d.ts'
+  },
   output: 'dist/rollup-extension-directory-plugin'
-}].map(({ input, output }) => (<rollup.RollupOptions>{
-  input: Object.fromEntries(input.map(input => ([
-    path.relative(path.resolve(DIST_DIR, 'types/src'), path.resolve(__dirname, '..', input)).slice(0, -3),
-    input
-  ]))),
+}]).map(({ input, output, preserveModulesRoot = TYPES_SRC_DIR, main = false }) => (<rollup.RollupOptions>{
+  input,
+  treeshake: false,
   output: {
     preserveModules: true,
-    preserveModulesRoot: 'dist/types/src',
+    preserveModulesRoot,
     format: 'esm',
     dir: output,
-    entryFileNames: chunk => `${chunk.name}.ts`,
-    chunkFileNames: chunk => `${chunk.name}.ts`,
-    assetFileNames: chunk => `${chunk.name}.ts`
-  },
-  external: function isExternal (id) {
-    if (id.endsWith('.css')) {
-      return true
+    entryFileNames: (chunkInfo) => {
+      // Rename node_modules to external so it's not removing while publishing the package
+      // tslib and rollup-plugin-styles and bundled
+      if (chunkInfo.name.includes('node_modules')) {
+        return chunkInfo.name.replace('node_modules', 'external') + '.ts'
+      }
+      return '[name].ts'
     }
-    if (id.includes('.contribution')) {
-      return true
-    }
-    return [
-      'vscode', 'monaco-editor', 'vscode-textmate', 'rollup', '@rollup/pluginutils',
-      'xterm', 'tas-client-umd', 'xterm-addon-canvas', 'xterm-addon-search', 'xterm-addon-unicode11',
-      'xterm-addon-webgl', 'xterm-addon-serialize', 'xterm-addon-image', 'xterm-headless'
-    ].includes(id)
   },
+  external: (id) => isExternal(id, main),
   plugins: [
+    metadataPlugin({
+      stage: 'writeBundle', // rollup-plugin-dts needs the file to exist on the disk
+      getGroup (id: string) {
+        if (id.startsWith(SERVICE_OVERRIDE_DIR)) {
+          return path.basename(id, '.d.ts')
+        }
+        return 'main'
+      },
+      async handle (groupName, dependencies, exclusiveModules, entrypoints, options, bundle) {
+        if (groupName === 'main') {
+          return
+        }
+
+        const serviceOverrideEntryPoint = Array.from(entrypoints)[0]!
+        const entrypointInfo = this.getModuleInfo(serviceOverrideEntryPoint)!
+
+        const groupBundle = await rollup.rollup({
+          input: {
+            'index.d': 'entrypoint'
+          },
+          external: (id) => isExternal(id, main),
+          plugins: [
+            {
+              name: 'loader',
+              resolveId (source, importer) {
+                if (source === 'entrypoint') {
+                  return source
+                }
+                if (source.startsWith('monaco-editor/')) {
+                  return null
+                }
+                const importerDir = path.dirname(path.resolve(DIST_DIR_MAIN, importer ?? '/'))
+                const resolved = path.resolve(importerDir, source)
+                const resolvedWithoutExtension = resolved.endsWith('.js') ? resolved.slice(0, -3) : resolved
+                const resolvedWithExtension = resolvedWithoutExtension.endsWith('.d.ts') ? resolvedWithoutExtension : `${resolvedWithoutExtension}.d.ts`
+
+                const isNotExclusive = (resolved.startsWith(path.resolve(DIST_DIR_MAIN, 'vscode')) || path.dirname(resolved) === path.resolve(DIST_DIR_MAIN, 'service-override')) && !exclusiveModules.has(resolvedWithExtension)
+
+                if (isNotExclusive) {
+                  // Those modules will be imported from external monaco-vscode-api
+                  const externalResolved = resolved.startsWith(DIST_DIR_VSCODE_SRC_MAIN) ? `vscode/vscode/${path.relative(DIST_DIR_VSCODE_SRC_MAIN, resolvedWithoutExtension)}` : `vscode/${path.relative(DIST_DIR_MAIN, resolvedWithoutExtension)}`
+                  return {
+                    id: externalResolved,
+                    external: true
+                  }
+                }
+
+                return undefined
+              },
+              load (id) {
+                if (id === 'entrypoint') {
+                  const serviceOverrideTypesPath = `${path.resolve(SERVICE_OVERRIDE_DIST_DIR, groupName)}`
+                  const codeLines: string[] = []
+                  if ((entrypointInfo.exports ?? []).includes('default')) {
+                    codeLines.push(`export { default } from '${serviceOverrideTypesPath}'`)
+                  }
+                  if ((entrypointInfo.exports ?? []).some(e => e !== 'default')) {
+                    codeLines.push(`export * from '${serviceOverrideTypesPath}'`)
+                  }
+                  return codeLines.join('\n')
+                }
+                if (id.startsWith('vscode/')) {
+                  return (bundle[path.relative('vscode', id)] as rollup.OutputChunk | undefined)?.code
+                }
+                return (bundle[path.relative(DIST_DIR_MAIN, id)] as rollup.OutputChunk | undefined)?.code
+              }
+            },
+            dts({
+              respectExternal: true
+            })
+          ]
+        })
+        await groupBundle.write({
+          preserveModules: true,
+          preserveModulesRoot: path.resolve(DIST_DIR, 'main/service-override'),
+          minifyInternalExports: false,
+          assetFileNames: 'assets/[name][extname]',
+          format: 'esm',
+          dir: path.resolve(DIST_DIR, `service-override-${paramCase(groupName)}`),
+          entryFileNames: '[name].ts',
+          hoistTransitiveImports: false
+        })
+        await groupBundle.close()
+
+        // remove exclusive files from main bundle to prevent them from being duplicated
+        await Promise.all(Array.from(exclusiveModules).filter(m => m.startsWith(DIST_DIR_MAIN)).map(async module => {
+          await fsPromise.rm(module)
+        }))
+      }
+    }),
     {
       name: 'change-unsupported-syntax',
       transform (code) {
@@ -127,7 +234,7 @@ export default rollup.defineConfig([{
         if (importee.startsWith('vscode/')) {
           return path.resolve(VSCODE_DIR, path.relative('vscode', `${importee}.d.ts`))
         }
-        if (!importee.startsWith('vs/') && importer != null && importer.startsWith(VSCODE_SRC_DIR)) {
+        if (importee.startsWith('.') && importer != null && importer.startsWith(VSCODE_SRC_DIR)) {
           importee = path.relative(VSCODE_SRC_DIR, path.resolve(path.dirname(importer), importee))
         }
         if (importee.startsWith('vs/')) {

--- a/scripts/generate-types
+++ b/scripts/generate-types
@@ -5,7 +5,7 @@ set -e
 tsc --project tsconfig.types.json
 
 # bundle them with rollup
-rollup --config rollup/rollup.types.config.ts --configPlugin 'typescript={tsconfig: `tsconfig.rollup-config-types.json`}'
+NODE_OPTIONS=--max_old_space_size=8192 rollup --config rollup/rollup.types.config.ts --configPlugin 'typescript={tsconfig: `tsconfig.rollup-config-types.json`}'
 
 # remove temporary files
 rm -rf ./dist/types

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -89,9 +89,9 @@ async function deltaExtensions (toAdd: IExtensionWithExtHostKind[], toRemove: IE
   await lastPromise
 }
 
-export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.LocalProcess, params: RegisterExtensionParams): RegisterLocalProcessExtensionResult
-export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.LocalWebWorker, params: RegisterExtensionParams): RegisterLocalExtensionResult
-export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.Remote, params: RegisterRemoteExtensionParams): RegisterRemoteExtensionResult
+export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.LocalProcess, params?: RegisterExtensionParams): RegisterLocalProcessExtensionResult
+export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.LocalWebWorker, params?: RegisterExtensionParams): RegisterLocalExtensionResult
+export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.Remote, params?: RegisterRemoteExtensionParams): RegisterRemoteExtensionResult
 export function registerExtension (manifest: IExtensionManifest, extHostKind?: ExtensionHostKind, params?: RegisterExtensionParams): RegisterExtensionResult
 export function registerExtension (manifest: IExtensionManifest, extHostKind?: ExtensionHostKind, { defaultNLS, builtin = manifest.publisher === 'vscode', path = '/' }: RegisterExtensionParams = {}): RegisterExtensionResult {
   const disposableStore = new DisposableStore()

--- a/src/missing-services.ts
+++ b/src/missing-services.ts
@@ -352,7 +352,7 @@ class EmptyEditorGroup implements IEditorGroup, IEditorGroupView {
 }
 
 const fakeActiveGroup = new EmptyEditorGroup()
-export class EmptyEditorGroupsService implements IEditorGroupsService {
+class EmptyEditorGroupsService implements IEditorGroupsService {
   readonly _serviceBrand = undefined
   getLayout = unsupported
   onDidChangeActiveGroup = Event.None

--- a/src/service-override/accessibility.ts
+++ b/src/service-override/accessibility.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { AccessibleViewService, IAccessibleViewService } from 'vs/workbench/contrib/accessibility/browser/accessibleView'

--- a/src/service-override/audioCue.ts
+++ b/src/service-override/audioCue.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { AudioCueService, IAudioCueService } from 'vs/platform/audioCues/browser/audioCueService'

--- a/src/service-override/bulkEdit.ts
+++ b/src/service-override/bulkEdit.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { IBulkEditService } from 'vs/editor/browser/services/bulkEditService'

--- a/src/service-override/configuration.ts
+++ b/src/service-override/configuration.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices, StandaloneServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { WorkspaceService } from 'vs/workbench/services/configuration/browser/configurationService'
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration'

--- a/src/service-override/debug.ts
+++ b/src/service-override/debug.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { IDebugService } from 'vs/workbench/contrib/debug/common/debug'

--- a/src/service-override/dialogs.ts
+++ b/src/service-override/dialogs.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import 'vs/workbench/browser/parts/dialogs/dialog.web.contribution'
 import { DialogService } from 'vs/workbench/services/dialogs/common/dialogService'

--- a/src/service-override/editor.ts
+++ b/src/service-override/editor.ts
@@ -1,4 +1,5 @@
-import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
+import { IEditorOverrideServices, StandaloneServices } from 'vs/editor/standalone/browser/standaloneServices'
+import { Event } from 'vs/base/common/event'
 import { IResolvedTextEditorModel } from 'vs/editor/common/services/resolverService'
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService'
 import { CodeEditorService } from 'vs/workbench/services/editor/browser/codeEditorService'
@@ -10,12 +11,135 @@ import { IReference } from 'vs/base/common/lifecycle'
 import { ITextEditorService, TextEditorService } from 'vs/workbench/services/textfile/common/textEditorService'
 import { Registry } from 'vs/platform/registry/common/platform'
 import { FILE_EDITOR_INPUT_ID } from 'vs/workbench/contrib/files/common/files'
-import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService'
+import { GroupOrientation, IEditorGroup, IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService'
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation'
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey'
+import { IEditorGroupView } from 'vs/workbench/browser/parts/editor/editor'
 import { MonacoDelegateEditorGroupsService, MonacoEditorService, OpenEditor } from './tools/editor'
 import { unsupported } from '../tools'
-import { EmptyEditorGroupsService } from '../missing-services'
 import 'vs/workbench/browser/parts/editor/editor.contribution'
+
+class EmptyEditorGroup implements IEditorGroup, IEditorGroupView {
+  onDidFocus = Event.None
+  onDidOpenEditorFail = Event.None
+  whenRestored = Promise.resolve()
+  get titleHeight () {
+    return unsupported()
+  }
+
+  disposed = false
+  setActive = unsupported
+  notifyIndexChanged = unsupported
+  relayout = unsupported
+  dispose = unsupported
+  toJSON = unsupported
+  preferredWidth?: number | undefined
+  preferredHeight?: number | undefined
+  get element () {
+    return unsupported()
+  }
+
+  minimumWidth = 0
+  maximumWidth = Number.POSITIVE_INFINITY
+  minimumHeight = 0
+  maximumHeight = Number.POSITIVE_INFINITY
+  onDidChange = Event.None
+  layout = unsupported
+  onDidModelChange = Event.None
+  onWillDispose = Event.None
+  onDidActiveEditorChange = Event.None
+  onWillCloseEditor = Event.None
+  onDidCloseEditor = Event.None
+  onWillMoveEditor = Event.None
+  onWillOpenEditor = Event.None
+  id = 0
+  index = 0
+  label = 'main'
+  ariaLabel = 'main'
+  activeEditorPane = undefined
+  activeEditor = null
+  previewEditor = null
+  count = 0
+  isEmpty = false
+  isLocked = false
+  stickyCount = 0
+  editors = []
+  get scopedContextKeyService (): IContextKeyService { return StandaloneServices.get(IContextKeyService) }
+  getEditors = () => []
+  findEditors = () => []
+  getEditorByIndex = () => undefined
+  getIndexOfEditor = unsupported
+  openEditor = unsupported
+  openEditors = unsupported
+  isPinned = () => false
+  isSticky = () => false
+  isActive = () => false
+  contains = () => false
+  moveEditor = unsupported
+  moveEditors = unsupported
+  copyEditor = unsupported
+  copyEditors = unsupported
+  closeEditor = unsupported
+  closeEditors = unsupported
+  closeAllEditors = unsupported
+  replaceEditors = unsupported
+  pinEditor = unsupported
+  stickEditor = unsupported
+  unstickEditor = unsupported
+  lock = unsupported
+  focus (): void {
+    // ignore
+  }
+
+  isFirst = unsupported
+  isLast = unsupported
+}
+
+const fakeActiveGroup = new EmptyEditorGroup()
+
+class EmptyEditorGroupsService implements IEditorGroupsService {
+  readonly _serviceBrand = undefined
+  getLayout = unsupported
+  onDidChangeActiveGroup = Event.None
+  onDidAddGroup = Event.None
+  onDidRemoveGroup = Event.None
+  onDidMoveGroup = Event.None
+  onDidActivateGroup = Event.None
+  onDidLayout = Event.None
+  onDidScroll = Event.None
+  onDidChangeGroupIndex = Event.None
+  onDidChangeGroupLocked = Event.None
+  get contentDimension (): never { return unsupported() }
+  activeGroup = fakeActiveGroup
+  get sideGroup (): never { return unsupported() }
+  groups = [fakeActiveGroup]
+  count = 0
+  orientation = GroupOrientation.HORIZONTAL
+  isReady = false
+  whenReady = Promise.resolve()
+  whenRestored = Promise.resolve()
+  hasRestorableState = false
+  getGroups = (): never[] => []
+  getGroup = (): undefined => undefined
+  activateGroup = unsupported
+  getSize = unsupported
+  setSize = unsupported
+  arrangeGroups = unsupported
+  applyLayout = unsupported
+  centerLayout = unsupported
+  isLayoutCentered = (): boolean => false
+  setGroupOrientation = unsupported
+  findGroup = (): undefined => undefined
+  addGroup = unsupported
+  removeGroup = unsupported
+  moveGroup = unsupported
+  mergeGroup = unsupported
+  mergeAllGroups = unsupported
+  copyGroup = unsupported
+  partOptions = {}
+  onDidChangeEditorPartOptions = Event.None
+  enforcePartOptions = unsupported
+}
 
 class MonacoEditorGroupsService extends MonacoDelegateEditorGroupsService<EmptyEditorGroupsService> {
   constructor (@IInstantiationService instantiationService: IInstantiationService) {

--- a/src/service-override/environment.ts
+++ b/src/service-override/environment.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { BrowserWorkbenchEnvironmentService, IBrowserWorkbenchEnvironmentService } from 'vs/workbench/services/environment/browser/environmentService'

--- a/src/service-override/files.ts
+++ b/src/service-override/files.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices, StandaloneServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { FileService } from 'vs/platform/files/common/fileService'

--- a/src/service-override/keybindings.ts
+++ b/src/service-override/keybindings.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices, StandaloneServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { WorkbenchKeybindingService } from 'vs/workbench/services/keybinding/browser/keybindingService'

--- a/src/service-override/languageDetectionWorker.ts
+++ b/src/service-override/languageDetectionWorker.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { LanguageDetectionService } from 'vs/workbench/services/languageDetection/browser/languageDetectionWorkerServiceImpl'

--- a/src/service-override/languages.ts
+++ b/src/service-override/languages.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { WorkbenchLanguageService } from 'vs/workbench/services/language/common/languageService'

--- a/src/service-override/layout.ts
+++ b/src/service-override/layout.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices, StandaloneServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { IWorkbenchLayoutService, PanelAlignment, Parts, Position } from 'vs/workbench/services/layout/browser/layoutService'
 import { ILayoutOffsetInfo, ILayoutService } from 'vs/platform/layout/browser/layoutService'

--- a/src/service-override/lifecycle.ts
+++ b/src/service-override/lifecycle.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { BrowserLifecycleService } from 'vs/workbench/services/lifecycle/browser/lifecycleService'

--- a/src/service-override/markers.ts
+++ b/src/service-override/markers.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import 'vs/workbench/contrib/markers/browser/markers.contribution'
 

--- a/src/service-override/model.ts
+++ b/src/service-override/model.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { ITextModelService } from 'vs/editor/common/services/resolverService'
 import { TextModelResolverService } from 'vs/workbench/services/textmodelResolver/common/textModelResolverService'

--- a/src/service-override/notifications.ts
+++ b/src/service-override/notifications.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { NotificationsToasts } from 'vs/workbench/browser/parts/notifications/notificationsToasts'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation'

--- a/src/service-override/output.ts
+++ b/src/service-override/output.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { URI } from 'vs/base/common/uri'

--- a/src/service-override/preferences.ts
+++ b/src/service-override/preferences.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences'

--- a/src/service-override/quickaccess.ts
+++ b/src/service-override/quickaccess.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { IInputBox, IInputOptions, IPickOptions, IQuickInputButton, IQuickInputService, IQuickNavigateConfiguration, IQuickPick, IQuickPickItem, IQuickWidget, QuickPickInput } from 'vs/platform/quickinput/common/quickInput'
 import { CancellationToken } from 'vs/base/common/cancellation'

--- a/src/service-override/remoteAgent.ts
+++ b/src/service-override/remoteAgent.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteAgentService'

--- a/src/service-override/search.ts
+++ b/src/service-override/search.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { ISearchService } from 'vs/workbench/services/search/common/search'

--- a/src/service-override/snippets.ts
+++ b/src/service-override/snippets.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices, StandaloneServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { ISnippetsService } from 'vs/workbench/contrib/snippets/browser/snippets'

--- a/src/service-override/terminal.ts
+++ b/src/service-override/terminal.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { IProcessReadyEvent, ITerminalBackend, ITerminalBackendRegistry, ITerminalChildProcess, ITerminalLaunchError, ITerminalProfile, ITerminalsLayoutInfo, TerminalExtensions, ITerminalLogService, IPtyHostLatencyMeasurement } from 'vs/platform/terminal/common/terminal'

--- a/src/service-override/textmate.ts
+++ b/src/service-override/textmate.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices, StandaloneServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { ITextMateTokenizationService } from 'vs/workbench/services/textMate/browser/textMateTokenizationFeature'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'

--- a/src/service-override/theme.ts
+++ b/src/service-override/theme.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { WorkbenchThemeService } from 'vs/workbench/services/themes/browser/workbenchThemeService'
 import { IThemeExtensionPoint } from 'vs/workbench/services/themes/common/workbenchThemeService'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'

--- a/src/service-override/viewBanner.ts
+++ b/src/service-override/viewBanner.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { BannerPart } from 'vs/workbench/browser/parts/banner/bannerPart'

--- a/src/service-override/viewStatusBar.ts
+++ b/src/service-override/viewStatusBar.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { StatusbarPart } from 'vs/workbench/browser/parts/statusbar/statusbarPart'

--- a/src/service-override/viewTitleBar.ts
+++ b/src/service-override/viewTitleBar.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { ITitleService } from 'vs/workbench/services/title/common/titleService'

--- a/src/service-override/views.ts
+++ b/src/service-override/views.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices, StandaloneServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { IViewContainersRegistry, IViewDescriptor, IViewDescriptorService, IViewsRegistry, IViewsService, ViewContainerLocation, Extensions as ViewExtensions } from 'vs/workbench/common/views'

--- a/src/service-override/workspaceTrust.ts
+++ b/src/service-override/workspaceTrust.ts
@@ -1,4 +1,3 @@
-import '../missing-services'
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { IWorkspaceTrustEnablementService, IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from 'vs/platform/workspace/common/workspaceTrust'

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,3 +1,4 @@
+import './missing-services'
 import Severity from 'vs/base/common/severity'
 import { IConfigurationChangeEvent } from 'vs/platform/configuration/common/configuration'
 import { ITextModelContentProvider } from 'vs/editor/common/services/resolverService'

--- a/src/services.ts
+++ b/src/services.ts
@@ -7,6 +7,7 @@ import { StorageScope, StorageTarget } from 'vscode/src/vs/platform/storage/comm
 import { IEditorOverrideServices, StandaloneServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { ServiceIdentifier } from 'vs/platform/instantiation/common/instantiation'
 import { IAction } from 'vs/base/common/actions'
+import { Disposable } from 'vs/base/common/lifecycle'
 import getLayoutServiceOverride from './service-override/layout'
 import getEnvironmentServiceOverride from './service-override/environment'
 import getExtensionsServiceOverride from './service-override/extensions'
@@ -14,7 +15,16 @@ import getFileServiceOverride from './service-override/files'
 import getQuickAccessOverride from './service-override/quickaccess'
 import { serviceInitializedBarrier, startup } from './lifecycle'
 
+let servicesInitialized = false
+StandaloneServices.withServices(() => {
+  servicesInitialized = true
+  return Disposable.None
+})
+
 export async function initialize (overrides: IEditorOverrideServices, container?: HTMLElement): Promise<void> {
+  if (servicesInitialized) {
+    throw new Error('The services are already initialized.')
+  }
   const instantiationService = StandaloneServices.initialize({
     ...getLayoutServiceOverride(container), // Always override layout service to break cyclic dependency with ICodeEditorService
     ...getEnvironmentServiceOverride(),


### PR DESCRIPTION
This PR does 3 things:
- It throws an error when trying to initialize the already-initialized service
- It extract the service-override code and types into their own package to make monaco-vscode-api as small as possible
- It makes it so the types of the monaco-vscode-api package don't refer to any external dependency other than monaco-editor or vscode (fix #201)

Can you confirm the issue is fixed @kaisalmen ? published as [1.82.5-next.0](https://www.npmjs.com/package/@codingame/monaco-vscode-api/v/1.82.5-next.0)