### PR TITLE
fix: swap toRemove & toAdd in deltaExtensions

### DIFF
--- a/src/service-override/extensions.ts
+++ b/src/service-override/extensions.ts
@@ -433,13 +433,13 @@ export class SimpleExtensionService extends AbstractExtensionService implements 
 
   public async deltaExtensions (toAdd: IExtensionWithExtHostKind[], toRemove: IExtension[]): Promise<void> {
     const extHostPicker = (this._extensionHostKindPicker as LocalBrowserExtensionHostKindPicker)
+    for (const extension of toRemove) {
+      extHostPicker.removeForcedExtensionHostKind(extension.identifier.id)
+    }
     for (const extension of toAdd) {
       if (extension.extHostKind != null) {
         extHostPicker.setForcedExtensionHostKind(extension.identifier.id, extension.extHostKind)
       }
-    }
-    for (const extension of toRemove) {
-      extHostPicker.removeForcedExtensionHostKind(extension.identifier.id)
     }
 
     await this._handleDeltaExtensions(new DeltaExtensionsQueueItem(toAdd, toRemove))


### PR DESCRIPTION
When we try to remove & add the same extension in a very short timeframe, it does not get initialized properly because it gets both added to `toRemove` and `toAdd`. When that happens, the extension is first added, and then immediately removed. By swapping `toRemove` and `toAdd` we ensure that the extension is first removed, and then newly added.

Here's similar code in VSCode where I think they encountered the same condition:

<img width="1111" alt="image" src="https://github.com/CodinGame/monaco-vscode-api/assets/587016/745e45d4-2c92-474e-a258-dd61709b7e6b">
