### PR TITLE
fix: use same paths as vscode for settings

### DIFF
--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -95,7 +95,7 @@ diagnostics.set(modelRef.object.textEditorModel!.uri, [{
   code: 42
 }])
 
-const settingsModelReference = await createModelReference(monaco.Uri.from({ scheme: 'user', path: '/settings.json' }), `{
+const settingsModelReference = await createModelReference(monaco.Uri.from({ scheme: 'user-store', path: '/User/settings.json' }), `{
   "workbench.colorTheme": "Default Dark+",
   "workbench.iconTheme": "vs-seti",
   "editor.autoClosingBrackets": "languageDefined",
@@ -134,7 +134,7 @@ settingEditor.addAction({
   contextMenuGroupId: 'custom'
 })
 
-const keybindingsModelReference = await createModelReference(monaco.Uri.from({ scheme: 'user', path: '/keybindings.json' }), `[
+const keybindingsModelReference = await createModelReference(monaco.Uri.from({ scheme: 'user-store', path: '/User/keybindings.json' }), `[
   {
     "key": "ctrl+d",
     "command": "editor.action.deleteLines",

--- a/src/service-override/files.ts
+++ b/src/service-override/files.ts
@@ -462,9 +462,7 @@ fileSystemProvider.register(0, new MkdirpOnWriteInMemoryFileSystemProvider())
 const extensionFileSystemProvider = new RegisteredFileSystemProvider(true)
 
 const providers: Record<string, IFileSystemProvider> = {
-  user: new InMemoryFileSystemProvider(),
   extension: extensionFileSystemProvider,
-  cache: new InMemoryFileSystemProvider(),
   logs: new InMemoryFileSystemProvider(),
   [Schemas.vscodeUserData]: new InMemoryFileSystemProvider(),
   [Schemas.tmp]: new InMemoryFileSystemProvider(),


### PR DESCRIPTION
VSCode stores its settings in these places (with schema `user-store`):

<img width="661" alt="image" src="https://github.com/CodinGame/monaco-vscode-api/assets/587016/9ee2d8be-046d-4a5c-8fcb-9a5a4f3bceca">

This PR changes our settings to store them there as well, so custom file providers for user data store can put/retrieve settings from there. This should make it possible to persist settings between sessions, if users decide to replace the `user-store` schema with e.g. an IndexedDB filesystem.

It would've been even better if we would get the `userRoamingDataHome` variable directly from the `EnvironmentService`, but since that service is only initialized lazily this is the best next thing.

Code is inspired from here: https://github.com/microsoft/vscode/blob/8cb6def308c41b2b2fd09c14fbbc49d3ec3d5d01/src/vs/platform/userDataProfile/common/userDataProfile.ts#L286-L289