### PR TITLE
fix: initialize editor features after participants have been run

### DIFF
--- a/scripts/vscode.patch
+++ b/scripts/vscode.patch
@@ -319,10 +319,19 @@ index 23d547570e9..31dfb4fd8d4 100644
  
  export * from 'vs/editor/editor.api';
 diff --git a/src/vs/editor/standalone/browser/standaloneServices.ts b/src/vs/editor/standalone/browser/standaloneServices.ts
-index 01f2c6987ac..5d6abf9d561 100644
+index 01f2c6987ac..fcd285d22b5 100644
 --- a/src/vs/editor/standalone/browser/standaloneServices.ts
 +++ b/src/vs/editor/standalone/browser/standaloneServices.ts
-@@ -517,10 +517,14 @@ export class StandaloneKeybindingService extends AbstractKeybindingService {
+@@ -89,8 +89,6 @@ import { DefaultConfiguration } from 'vs/platform/configuration/common/configura
+ import { WorkspaceEdit } from 'vs/editor/common/languages';
+ import { AudioCue, IAudioCueService, Sound } from 'vs/platform/audioCues/browser/audioCueService';
+ import { LogService } from 'vs/platform/log/common/logService';
+-import { getEditorFeatures } from 'vs/editor/common/editorFeatures';
+-import { onUnexpectedError } from 'vs/base/common/errors';
+ import { ExtensionKind, IEnvironmentService, IExtensionHostDebugParams } from 'vs/platform/environment/common/environment';
+ 
+ class SimpleModel implements IResolvedTextEditorModel {
+@@ -517,10 +515,14 @@ export class StandaloneKeybindingService extends AbstractKeybindingService {
  		this._onDidUpdateKeybindings.fire();
  	}
  
@@ -338,6 +347,23 @@ index 01f2c6987ac..5d6abf9d561 100644
  			this._cachedResolver = new KeybindingResolver(defaults, overrides, (str) => this._log(str));
  		}
  		return this._cachedResolver;
+@@ -1155,16 +1157,6 @@ export module StandaloneServices {
+ 			}
+ 		}
+ 
+-		// Instantiate all editor features
+-		const editorFeatures = getEditorFeatures();
+-		for (const feature of editorFeatures) {
+-			try {
+-				instantiationService.createInstance(feature);
+-			} catch (err) {
+-				onUnexpectedError(err);
+-			}
+-		}
+-
+ 		onDidInitialize.fire();
+ 
+ 		return instantiationService;
 diff --git a/src/vs/nls.ts b/src/vs/nls.ts
 index db57b98d67b..defd683e0b0 100644
 --- a/src/vs/nls.ts

--- a/src/monaco.ts
+++ b/src/monaco.ts
@@ -63,6 +63,7 @@ import 'vs/workbench/contrib/folding/browser/folding.contribution'
 import 'vs/workbench/contrib/inlayHints/browser/inlayHintsAccessibilty'
 import 'vs/workbench/contrib/codeActions/browser/codeActions.contribution'
 import 'vs/workbench/contrib/list/browser/list.contribution'
+import 'vs/workbench/contrib/codeEditor/browser/editorFeatures'
 
 class ExtensionPoints implements IWorkbenchContribution {
   constructor (


### PR DESCRIPTION
Fixes https://github.com/CodinGame/monaco-vscode-api/issues/231

With this change, we ensure that editor features are only initialized _after_ we've run our init participants. This ensures that the `WorkbenchThemeService` is not initialized before the `StorageService` is initialized, because `WorkbenchThemeService` already calls to the `StorageService` in its constructor.

The risky thing here is that we're changing how StandaloneServices works. This is one approach, the other approach that we can take is initialization of some services manually, and then register those as part of the service collection initialization.