### PR TITLE
feat: expose activity services

### DIFF
--- a/src/service-override/views.ts
+++ b/src/service-override/views.ts
@@ -739,5 +739,9 @@ export {
   SidebarPart,
   ActivitybarPart,
   PanelPart,
-  Parts
+  Parts,
+
+  IActivityService,
+  IViewDescriptorService,
+  IPaneCompositePartService
 }


### PR DESCRIPTION
This PR exposes some internal interfaces for activity services. I'm currently working on using the sidebar of VSCode, while still rendering our own activitybar. To know which view is currently opened, and which views are available, I _believe_ I will need these interfaces.