### PR TITLE
feat: expose `WorkspaceService`

### DIFF
--- a/src/service-override/configuration.ts
+++ b/src/service-override/configuration.ts
@@ -124,6 +124,11 @@ registerServiceInitializePreParticipant(async (accessor) => {
 
 const MemoizedInjectedConfigurationService = memoizedConstructor(InjectedConfigurationService)
 
+export async function reinitializeWorkspace (workspace: IAnyWorkspaceIdentifier): Promise<void> {
+  const workspaceService = StandaloneServices.get(IWorkspaceContextService) as WorkspaceService
+  await workspaceService.initialize(workspace)
+}
+
 export default function getServiceOverride (defaultWorkspace: URI | IAnyWorkspaceIdentifier): IEditorOverrideServices {
   _defaultWorkspace = defaultWorkspace
 


### PR DESCRIPTION
We sometimes want to reinitialize the workspace (e.g. when the user decides to change their folders). For this, we need to run:

```ts
const workspaceService = accessor.get(IWorkspaceContextService) as WorkspaceService
workspaceService.initialize(...)
```

So we can call `initialize` on it. To be able to do this, we need to be able to access the `WorkspaceService` type.

In this case I decided to expose it from `configuration.ts`, since it's only used when this service overridden. But let me know if you'd prefer to expose this from services!