### PR TITLE
Fix editor.addAction keybindings

### DIFF
--- a/scripts/vscode.patch
+++ b/scripts/vscode.patch
@@ -397,7 +397,7 @@ index 23d547570e9..31dfb4fd8d4 100644
  
  export * from 'vs/editor/editor.api';
 diff --git a/src/vs/editor/standalone/browser/standaloneServices.ts b/src/vs/editor/standalone/browser/standaloneServices.ts
-index 01f2c6987ac..fcd285d22b5 100644
+index 01f2c6987ac..a4853357178 100644
 --- a/src/vs/editor/standalone/browser/standaloneServices.ts
 +++ b/src/vs/editor/standalone/browser/standaloneServices.ts
 @@ -89,8 +89,6 @@ import { DefaultConfiguration } from 'vs/platform/configuration/common/configura
@@ -425,6 +425,15 @@ index 01f2c6987ac..fcd285d22b5 100644
  			this._cachedResolver = new KeybindingResolver(defaults, overrides, (str) => this._log(str));
  		}
  		return this._cachedResolver;
+@@ -541,7 +543,7 @@ export class StandaloneKeybindingService extends AbstractKeybindingService {
+ 				// This might be a removal keybinding item in user settings => accept it
+ 				result[resultLen++] = new ResolvedKeybindingItem(undefined, item.command, item.commandArgs, when, isDefault, null, false);
+ 			} else {
+-				const resolvedKeybindings = USLayoutResolvedKeybinding.resolveKeybinding(keybinding, OS);
++				const resolvedKeybindings = this.resolveKeybinding(keybinding);
+ 				for (const resolvedKeybinding of resolvedKeybindings) {
+ 					result[resultLen++] = new ResolvedKeybindingItem(resolvedKeybinding, item.command, item.commandArgs, when, isDefault, null, false);
+ 				}
 @@ -1155,16 +1157,6 @@ export module StandaloneServices {
  			}
  		}

--- a/src/monaco.ts
+++ b/src/monaco.ts
@@ -42,7 +42,7 @@ import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService
 import { IKeybindingService, IKeyboardEvent } from 'vs/platform/keybinding/common/keybinding'
 import { KeybindingResolver } from 'vs/platform/keybinding/common/keybindingResolver'
 import { ResolvedKeybindingItem } from 'vs/platform/keybinding/common/resolvedKeybindingItem'
-import { ResolvedKeybinding } from 'vs/base/common/keybindings'
+import { Keybinding, ResolvedKeybinding } from 'vs/base/common/keybindings'
 import { createInjectedClass } from './tools/injection'
 // Selectively comes from vs/workbench/contrib/codeEditor/browser/codeEditor.contribution.ts
 import 'vs/workbench/contrib/codeEditor/browser/workbenchReferenceSearch'
@@ -215,6 +215,10 @@ class DelegateStandaloneKeybindingService extends StandaloneKeybindingService {
 
   override resolveKeyboardEvent (keyboardEvent: IKeyboardEvent): ResolvedKeybinding {
     return this.delegate.resolveKeyboardEvent(keyboardEvent)
+  }
+
+  override resolveKeybinding (keybinding: Keybinding): ResolvedKeybinding[] {
+    return this.delegate.resolveKeybinding(keybinding)
   }
 }
 


### PR DESCRIPTION
ctrl+K in the demo doesn't work anymore

Not sure about what caused the regression, don't know how it was working

fix #244