### PR TITLE
Include editor serializers in the final bundle

### DIFF
--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -5,7 +5,7 @@ import url from 'url'
 import path from 'path'
 import pkg from './package.json' assert { type: 'json' }
 
-const cdnDomain = 'http://127.0.0.2:5173'
+const cdnDomain = process.env.CDN_HOST ?? 'http://127.0.0.2:5173'
 
 export default defineConfig({
   build: {

--- a/rollup/rollup.config.ts
+++ b/rollup/rollup.config.ts
@@ -68,7 +68,6 @@ const FUNCTIONS_TO_REMOVE = new Set([
   'registerViewWelcomeContent',
   'registerExtensionPoint',
   'registerTouchBarEntry',
-  'registerEditorSerializer',
 
   // For ActivityBar, remove unused actions/items
   'fillExtraContextMenuActions',


### PR DESCRIPTION
You were right, only the grid layout was restored because the editors didn't have serializers attached to them. With this change, we include the editor serializers in the final bundle, which allows VSCode to recover the exact view state (also for other editors than file editors).

I've tested this in the demo, and now it recovers correctly.