### PR TITLE
Fix workspace initialization

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -22,7 +22,7 @@
           <button id="run">Run with debugger</button>
           <button id="filesystem">Attach filesystem</button>
           <button id="customEditorPanel">Open custom editor panel</button>
-          <button id="clearStorage">Clear storage</button>
+          <button id="clearStorage">Clear user data</button>
           <br />
           <button id="togglePanel">Toggle Panel</button>
           <button id="toggleAuxiliary">Toggle Secondary Panel</button>

--- a/demo/index.html
+++ b/demo/index.html
@@ -55,9 +55,11 @@
 
       <h1>Settings</h1>
       <button id="settingsui">Open settings UI</button>
+      <button id="resetsettings">Reset settings</button>
       <div id="settings-editor" class="standalone-editor"></div>
       <h1>Keybindings</h1>
       <button id="keybindingsui">Open keybindings UI</button>
+      <button id="resetkeybindings">Reset keybindings</button>
       <div id="keybindings-editor" class="standalone-editor"></div>
     </div>
     <script type="module" src="/src/loader.ts"></script>

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -5,8 +5,8 @@ import { registerFileSystemOverlay, HTMLFileSystemProvider } from '@codingame/mo
 import * as vscode from 'vscode'
 import { ILogService, StandaloneServices, IPreferencesService, IEditorService, IDialogService, getService, createInstance } from 'vscode/services'
 import { Parts, isPartVisibile, setPartVisibility } from '@codingame/monaco-vscode-views-service-override'
-import { defaultUserConfigurationFile } from '@codingame/monaco-vscode-configuration-service-override'
-import { defaultUserKeybindindsFile } from '@codingame/monaco-vscode-keybindings-service-override'
+import { defaultUserConfigurationFile, updateUserConfiguration } from '@codingame/monaco-vscode-configuration-service-override'
+import { defaultUserKeybindindsFile, updateUserKeybindings } from '@codingame/monaco-vscode-keybindings-service-override'
 import { clearStorage, remoteAuthority } from './setup'
 import { CustomEditorInput } from './features/customView'
 import './features/debugger'
@@ -57,6 +57,8 @@ import '@codingame/monaco-vscode-configuration-editing-default-extension'
 import '@codingame/monaco-vscode-markdown-math-default-extension'
 import '@codingame/monaco-vscode-npm-default-extension'
 import '@codingame/monaco-vscode-media-preview-default-extension'
+import defaultConfiguration from './user/configuration.json?raw'
+import defaultKeybindings from './user/keybindings.json?raw'
 
 if (remoteAuthority != null) {
   import('./features/remoteExtension')
@@ -143,6 +145,14 @@ document.querySelector('#run')!.addEventListener('click', () => {
 document.querySelector('#settingsui')!.addEventListener('click', async () => {
   await StandaloneServices.get(IPreferencesService).openUserSettings()
   window.scrollTo({ top: 0, behavior: 'smooth' })
+})
+
+document.querySelector('#resetsettings')!.addEventListener('click', async () => {
+  await updateUserConfiguration(defaultConfiguration)
+})
+
+document.querySelector('#resetkeybindings')!.addEventListener('click', async () => {
+  await updateUserKeybindings(defaultKeybindings)
 })
 
 document.querySelector('#keybindingsui')!.addEventListener('click', async () => {

--- a/demo/src/setup.ts
+++ b/demo/src/setup.ts
@@ -48,7 +48,7 @@ import { toCrossOriginWorker, toWorkerConfig } from './tools/workers'
 import defaultConfiguration from './user/configuration.json?raw'
 import defaultKeybindings from './user/keybindings.json?raw'
 
-await createIndexedDBProviders()
+const userDataProvider = await createIndexedDBProviders()
 
 // Workers
 export type WorkerLoader = () => Worker
@@ -129,6 +129,7 @@ await initializeMonacoService({
 StandaloneServices.get(ILogService).setLevel(LogLevel.Off)
 
 export async function clearStorage (): Promise<void> {
+  await userDataProvider.reset()
   await (await getService(IStorageService) as BrowserStorageService).clear()
 }
 

--- a/demo/src/setup.ts
+++ b/demo/src/setup.ts
@@ -38,6 +38,7 @@ import getWorkspaceTrustOverride from '@codingame/monaco-vscode-workspace-trust-
 import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker.js?worker'
 import TextMateWorker from '@codingame/monaco-vscode-textmate-service-override/worker?worker'
 import OutputLinkComputerWorker from '@codingame/monaco-vscode-output-service-override/worker?worker'
+import { createIndexedDBProviders } from '@codingame/monaco-vscode-files-service-override'
 import ExtensionHostWorker from 'vscode/workers/extensionHost.worker?worker'
 import LanguageDetectionWorker from '@codingame/monaco-vscode-language-detection-worker-service-override/worker?worker'
 import * as monaco from 'monaco-editor'
@@ -46,6 +47,8 @@ import { openNewCodeEditor } from './features/editor'
 import { toCrossOriginWorker, toWorkerConfig } from './tools/workers'
 import defaultConfiguration from './user/configuration.json?raw'
 import defaultKeybindings from './user/keybindings.json?raw'
+
+await createIndexedDBProviders()
 
 // Workers
 export type WorkerLoader = () => Worker

--- a/demo/src/setup.ts
+++ b/demo/src/setup.ts
@@ -44,6 +44,8 @@ import * as monaco from 'monaco-editor'
 import { TerminalBackend } from './features/terminal'
 import { openNewCodeEditor } from './features/editor'
 import { toCrossOriginWorker, toWorkerConfig } from './tools/workers'
+import defaultConfiguration from './user/configuration.json?raw'
+import defaultKeybindings from './user/keybindings.json?raw'
 
 // Workers
 export type WorkerLoader = () => Worker
@@ -70,35 +72,8 @@ const remotePath = remoteAuthority != null ? params.get('remotePath') ?? undefin
 
 // Set configuration before initializing service so it's directly available (especially for the theme, to prevent a flicker)
 await Promise.all([
-  initUserConfiguration(`{
-    "workbench.colorTheme": "Default Dark+",
-    "workbench.iconTheme": "vs-seti",
-    "editor.autoClosingBrackets": "languageDefined",
-    "editor.autoClosingQuotes": "languageDefined",
-    "editor.scrollBeyondLastLine": true,
-    "editor.mouseWheelZoom": true,
-    "editor.wordBasedSuggestions": false,
-    "editor.acceptSuggestionOnEnter": "on",
-    "editor.foldingHighlight": false,
-    "editor.semanticHighlighting.enabled": true,
-    "editor.bracketPairColorization.enabled": false,
-    "editor.fontSize": 12,
-    "audioCues.lineHasError": "on",
-    "audioCues.onDebugBreak": "on",
-    "files.autoSave": "afterDelay",
-    "files.autoSaveDelay": 1000,
-    "debug.toolBarLocation": "docked",
-    "editor.experimental.asyncTokenization": true,
-    "terminal.integrated.tabs.title": "\${sequence}",
-    "typescript.tsserver.log": "normal"
-  }`),
-  initUserKeybindings(`[
-    {
-      "key": "ctrl+d",
-      "command": "editor.action.deleteLines",
-      "when": "editorTextFocus"
-    }
-  ]`)
+  initUserConfiguration(defaultConfiguration),
+  initUserKeybindings(defaultKeybindings)
 ])
 
 // Override services

--- a/demo/src/setup.ts
+++ b/demo/src/setup.ts
@@ -82,9 +82,7 @@ await initializeMonacoService({
   ...getModelServiceOverride(),
   ...getNotificationServiceOverride(),
   ...getDialogsServiceOverride(),
-  ...getConfigurationServiceOverride(remotePath == null
-    ? monaco.Uri.file('/tmp')
-    : { id: 'remote-workspace', uri: monaco.Uri.from({ scheme: 'vscode-remote', path: remotePath, authority: remoteAuthority }) }),
+  ...getConfigurationServiceOverride(),
   ...getKeybindingsServiceOverride(),
   ...getTextmateServiceOverride(),
   ...getThemeServiceOverride(),
@@ -92,7 +90,7 @@ await initializeMonacoService({
   ...getAudioCueServiceOverride(),
   ...getDebugServiceOverride(),
   ...getPreferencesServiceOverride(),
-  ...getViewsServiceOverride(openNewCodeEditor),
+  ...getViewsServiceOverride(openNewCodeEditor, undefined, true),
   ...getBannerServiceOverride(),
   ...getStatusBarServiceOverride(),
   ...getTitleBarServiceOverride(),
@@ -110,11 +108,20 @@ await initializeMonacoService({
   ...getStorageServiceOverride(),
   ...getRemoteAgentServiceOverride(connectionToken),
   ...getLifecycleServiceOverride(),
-  ...getEnvironmentServiceOverride({
-    remoteAuthority,
-    enableWorkspaceTrust: true
-  }),
+  ...getEnvironmentServiceOverride(),
   ...getWorkspaceTrustOverride()
+}, document.body, {
+  remoteAuthority,
+  enableWorkspaceTrust: true,
+  workspaceProvider: {
+    trusted: true,
+    async open () {
+      return false
+    },
+    workspace: {
+      folderUri: remotePath == null ? monaco.Uri.file('/tmp') : monaco.Uri.from({ scheme: 'vscode-remote', path: remotePath, authority: remoteAuthority })
+    }
+  }
 })
 StandaloneServices.get(ILogService).setLevel(LogLevel.Off)
 

--- a/demo/src/user/configuration.json
+++ b/demo/src/user/configuration.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorTheme": "Default Dark+",
+    "workbench.iconTheme": "vs-seti",
+    "editor.autoClosingBrackets": "languageDefined",
+    "editor.autoClosingQuotes": "languageDefined",
+    "editor.scrollBeyondLastLine": true,
+    "editor.mouseWheelZoom": true,
+    "editor.wordBasedSuggestions": false,
+    "editor.acceptSuggestionOnEnter": "on",
+    "editor.foldingHighlight": false,
+    "editor.semanticHighlighting.enabled": true,
+    "editor.bracketPairColorization.enabled": false,
+    "editor.fontSize": 12,
+    "audioCues.lineHasError": "on",
+    "audioCues.onDebugBreak": "on",
+    "files.autoSave": "afterDelay",
+    "files.autoSaveDelay": 1000,
+    "debug.toolBarLocation": "docked",
+    "editor.experimental.asyncTokenization": true,
+    "terminal.integrated.tabs.title": "${sequence}",
+    "typescript.tsserver.log": "normal"
+}

--- a/demo/src/user/keybindings.json
+++ b/demo/src/user/keybindings.json
@@ -1,0 +1,7 @@
+[
+    {
+      "key": "ctrl+d",
+      "command": "editor.action.deleteLines",
+      "when": "editorTextFocus"
+    }
+]

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -59,7 +59,7 @@ export default defineConfig({
       // These 2 lines prevent vite from reloading the whole page when starting a worker (so 2 times in a row after cleaning the vite cache - for the editor then the textmate workers)
       // it's mainly empirical and probably not the best way, fix me if you find a better way
       'monaco-editor/esm/vs/nls.js', 'monaco-editor/esm/vs/editor/editor.worker.js', 'vscode-textmate', 'vscode-oniguruma', '@vscode/vscode-languagedetection',
-      ...(await glob('monaco-editor/esm/vs/**/common/**/*.js', { cwd: path.resolve(__dirname, '../node_modules') })),
+      ...(await glob('monaco-editor/esm/vs/**/common/**/*.js', { cwd: path.resolve(__dirname, '../node_modules') }))
     ],
     exclude: [],
     esbuildOptions: {

--- a/rollup/rollup.config.ts
+++ b/rollup/rollup.config.ts
@@ -859,6 +859,10 @@ export default (args: Record<string, string>): rollup.RollupOptions[] => {
                 types: './lifecycle.d.ts',
                 default: './lifecycle.js'
               },
+              './workbench': {
+                types: './workbench.d.ts',
+                default: './workbench.js'
+              },
               './service-override/*': {
                 types: './service-override/*.d.ts',
                 default: './service-override/*.js'
@@ -897,6 +901,9 @@ export default (args: Record<string, string>): rollup.RollupOptions[] => {
                 ],
                 lifecycle: [
                   './lifecycle.d.ts'
+                ],
+                workbench: [
+                  './workbench.d.ts'
                 ],
                 l10n: [
                   './l10n.d.ts'
@@ -988,7 +995,7 @@ export default (args: Record<string, string>): rollup.RollupOptions[] => {
                   const resolvedWithExtension = resolved.endsWith('.js') ? resolved : `${resolved}.js`
 
                   const isNotExclusive = (resolved.startsWith(VSCODE_SRC_DIST_DIR) || path.dirname(resolved) === path.resolve(DIST_DIR_MAIN, 'service-override')) && !exclusiveModules.has(resolvedWithExtension)
-                  const shouldBeShared = resolvedWithExtension === path.resolve(DIST_DIR_MAIN, 'assets.js') || resolvedWithExtension === path.resolve(DIST_DIR_MAIN, 'lifecycle.js')
+                  const shouldBeShared = resolvedWithExtension === path.resolve(DIST_DIR_MAIN, 'assets.js') || resolvedWithExtension === path.resolve(DIST_DIR_MAIN, 'lifecycle.js') || resolvedWithExtension === path.resolve(DIST_DIR_MAIN, 'workbench.js')
 
                   if (isNotExclusive || shouldBeShared) {
                     // Those modules will be imported from external monaco-vscode-api

--- a/rollup/rollup.default-extensions.ts
+++ b/rollup/rollup.default-extensions.ts
@@ -83,20 +83,6 @@ export default rollup.defineConfig([
       extensionDirectoryPlugin({
         include: `${DEFAULT_EXTENSIONS_PATH}/**/*`,
         transformManifest (manifest) {
-          if (manifest.name === 'configuration-editing') {
-            manifest = {
-              ...manifest,
-              contributes: {
-                ...manifest.contributes,
-                jsonValidation: manifest.contributes!.jsonValidation!.map(validation => {
-                  return {
-                    fileMatch: (validation.fileMatch as string).replaceAll('%APP_SETTINGS_HOME%', 'user:'),
-                    url: validation.url
-                  }
-                })
-              }
-            }
-          }
           return {
             ...manifest,
             main: undefined

--- a/scripts/vscode.patch
+++ b/scripts/vscode.patch
@@ -397,7 +397,7 @@ index 23d547570e9..31dfb4fd8d4 100644
  
  export * from 'vs/editor/editor.api';
 diff --git a/src/vs/editor/standalone/browser/standaloneServices.ts b/src/vs/editor/standalone/browser/standaloneServices.ts
-index 01f2c6987ac..a4853357178 100644
+index 01f2c6987ac..e3bf9b1e9e4 100644
 --- a/src/vs/editor/standalone/browser/standaloneServices.ts
 +++ b/src/vs/editor/standalone/browser/standaloneServices.ts
 @@ -89,8 +89,6 @@ import { DefaultConfiguration } from 'vs/platform/configuration/common/configura
@@ -409,7 +409,13 @@ index 01f2c6987ac..a4853357178 100644
  import { ExtensionKind, IEnvironmentService, IExtensionHostDebugParams } from 'vs/platform/environment/common/environment';
  
  class SimpleModel implements IResolvedTextEditorModel {
-@@ -517,10 +515,14 @@ export class StandaloneKeybindingService extends AbstractKeybindingService {
+@@ -512,15 +510,19 @@ export class StandaloneKeybindingService extends AbstractKeybindingService {
+ 		});
+ 	}
+ 
+-	private updateResolver(): void {
++	protected updateResolver(): void {
+ 		this._cachedResolver = null;
  		this._onDidUpdateKeybindings.fire();
  	}
  

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -4,6 +4,7 @@ import { ILifecycleService, LifecyclePhase } from 'vs/workbench/services/lifecyc
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation'
 import { Barrier, RunOnceScheduler, runWhenIdle } from 'vs/base/common/async'
 import { Emitter } from 'vs/base/common/event'
+import { EditorExtensions, IEditorFactoryRegistry } from 'vs/workbench/common/editor'
 
 const renderWorkbenchEmitter = new Emitter<ServicesAccessor>()
 export const onRenderWorkbench = renderWorkbenchEmitter.event
@@ -52,6 +53,7 @@ export async function startup (instantiationService: IInstantiationService): Pro
     const lifecycleService = accessor.get(ILifecycleService)
 
     Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).start(accessor)
+    Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).start(accessor)
 
     renderWorkbenchEmitter.fire(accessor)
 

--- a/src/service-override/dialogs.ts
+++ b/src/service-override/dialogs.ts
@@ -60,10 +60,10 @@ class FileDialogService extends AbstractFileDialogService {
   }
 }
 
-export default function getServiceOverride (container?: HTMLElement): IEditorOverrideServices {
+export default function getServiceOverride (): IEditorOverrideServices {
   return {
     [IDialogService.toString()]: new SyncDescriptor(DialogService, undefined, true),
     [IFileDialogService.toString()]: new SyncDescriptor(FileDialogService, undefined, true),
-    ...getLayoutServiceOverride(container)
+    ...getLayoutServiceOverride()
   }
 }

--- a/src/service-override/environment.ts
+++ b/src/service-override/environment.ts
@@ -1,23 +1,31 @@
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
 import { BrowserWorkbenchEnvironmentService, IBrowserWorkbenchEnvironmentService } from 'vs/workbench/services/environment/browser/environmentService'
-import { URI } from 'vs/base/common/uri'
 import { IEnvironmentService } from 'vs/platform/environment/common/environment'
 import { IProductService } from 'vs/platform/product/common/productService'
 import { IWorkbenchConstructionOptions } from 'vs/workbench/browser/web.api'
+import { getWorkbenchConstructionOptions, getWorkspaceIdentifier, logsPath } from '../workbench'
 
 class InjectedBrowserWorkbenchEnvironmentService extends BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvironmentService {
-  constructor (options: IWorkbenchConstructionOptions, @IProductService productService: IProductService) {
-    super('default', URI.from({ scheme: 'logs', path: '/' }), options, productService)
+  constructor (workspaceId: string = getWorkspaceIdentifier().id, options: IWorkbenchConstructionOptions = getWorkbenchConstructionOptions(), @IProductService productService: IProductService) {
+    super(workspaceId, logsPath, options, productService)
   }
 }
 
-export default function getServiceOverride (options: IWorkbenchConstructionOptions = {}): IEditorOverrideServices {
+/**
+ * @deprecated Provide construction option via the services `initialize` function `configuration` parameter
+ */
+function getServiceOverride (options: IWorkbenchConstructionOptions): IEditorOverrideServices
+function getServiceOverride (): IEditorOverrideServices
+
+function getServiceOverride (options?: IWorkbenchConstructionOptions): IEditorOverrideServices {
   return {
     [IEnvironmentService.toString()]: new SyncDescriptor(InjectedBrowserWorkbenchEnvironmentService, [], true),
-    [IBrowserWorkbenchEnvironmentService.toString()]: new SyncDescriptor(InjectedBrowserWorkbenchEnvironmentService, [options], true)
+    [IBrowserWorkbenchEnvironmentService.toString()]: new SyncDescriptor(InjectedBrowserWorkbenchEnvironmentService, [undefined, options], true)
   }
 }
+
+export default getServiceOverride
 
 export {
   IWorkbenchConstructionOptions

--- a/src/service-override/files.ts
+++ b/src/service-override/files.ts
@@ -522,6 +522,14 @@ export async function initFile (scheme: string, file: URI, content: Uint8Array |
   if (provider == null || provider.writeFile == null) {
     throw new Error(`${scheme} provider doesn't exist or doesn't support writing files`)
   }
+  if (!(options?.overwrite ?? false)) {
+    try {
+      await provider.stat(file)
+      // The file already exists, do nothing
+      return
+    } catch (error) {
+    }
+  }
 
   await provider.writeFile(file, content instanceof Uint8Array ? content : encoder.encode(content), {
     atomic: false,

--- a/src/service-override/files.ts
+++ b/src/service-override/files.ts
@@ -15,6 +15,7 @@ import 'vs/workbench/contrib/files/browser/files.contribution.js?include=registe
 import { Schemas } from 'vs/base/common/network'
 import { IndexedDBFileSystemProvider } from 'vs/platform/files/browser/indexedDBFileSystemProvider'
 import { IndexedDB } from 'vs/base/browser/indexedDB'
+import { logsPath } from '../workbench'
 
 abstract class RegisteredFile {
   private ctime: number
@@ -468,7 +469,7 @@ void userDataFileSystemProvider.mkdir(URI.from({ scheme: Schemas.vscodeUserData,
 
 const providers: Record<string, IFileSystemProvider> = {
   extension: extensionFileSystemProvider,
-  logs: new InMemoryFileSystemProvider(),
+  [logsPath.scheme]: new InMemoryFileSystemProvider(),
   [Schemas.vscodeUserData]: userDataFileSystemProvider,
   [Schemas.tmp]: new InMemoryFileSystemProvider(),
   file: fileSystemProvider

--- a/src/service-override/files.ts
+++ b/src/service-override/files.ts
@@ -543,7 +543,7 @@ export async function initFile (scheme: string, file: URI, content: Uint8Array |
 /**
  * Can be used to replace memory providers by indexeddb providers before the fileService is initialized
  */
-export async function createIndexedDBProviders (): Promise<void> {
+export async function createIndexedDBProviders (): Promise<IndexedDBFileSystemProvider> {
   const userDataStore = 'vscode-userdata-store'
   const logsStore = 'vscode-logs-store'
   const indexedDB = await IndexedDB.create('vscode-web-db', 3, [userDataStore, logsStore])
@@ -553,6 +553,8 @@ export async function createIndexedDBProviders (): Promise<void> {
 
   const userDataProvider = new IndexedDBFileSystemProvider(Schemas.vscodeUserData, indexedDB, userDataStore, true)
   providers[Schemas.vscodeUserData] = userDataProvider
+
+  return userDataProvider
 }
 
 /**

--- a/src/service-override/files.ts
+++ b/src/service-override/files.ts
@@ -13,8 +13,9 @@ import { HTMLFileSystemProvider } from 'vs/platform/files/browser/htmlFileSystem
 import * as path from 'vs/base/common/path'
 import 'vs/workbench/contrib/files/browser/files.contribution.js?include=registerConfiguration'
 import { Schemas } from 'vs/base/common/network'
-import { IndexedDBFileSystemProvider } from 'vs/platform/files/browser/indexedDBFileSystemProvider'
+import { IndexedDBFileSystemProvider, IndexedDBFileSystemProviderErrorData, IndexedDBFileSystemProviderErrorDataClassification } from 'vs/platform/files/browser/indexedDBFileSystemProvider'
 import { IndexedDB } from 'vs/base/browser/indexedDB'
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry'
 import { logsPath } from '../workbench'
 
 abstract class RegisteredFile {
@@ -476,7 +477,7 @@ const providers: Record<string, IFileSystemProvider> = {
 }
 
 class MemoryFileService extends FileService {
-  constructor (@ILogService logService: ILogService) {
+  constructor (@ILogService logService: ILogService, @ITelemetryService telemetryService: ITelemetryService) {
     super(logService)
 
     for (const [scheme, provider] of Object.entries(providers)) {
@@ -486,6 +487,10 @@ class MemoryFileService extends FileService {
           disposable.dispose()
           disposable = this.registerProvider(scheme, fileSystemProvider)
         })
+      }
+
+      if (provider instanceof IndexedDBFileSystemProvider) {
+        this._register(provider.onReportError(e => telemetryService.publicLog2<IndexedDBFileSystemProviderErrorData, IndexedDBFileSystemProviderErrorDataClassification>('indexedDBFileSystemProviderError', e)))
       }
     }
   }
@@ -525,6 +530,21 @@ export async function initFile (scheme: string, file: URI, content: Uint8Array |
     unlock: false,
     ...options
   })
+}
+
+/**
+ * Can be used to replace memory providers by indexeddb providers before the fileService is initialized
+ */
+export async function createIndexedDBProviders (): Promise<void> {
+  const userDataStore = 'vscode-userdata-store'
+  const logsStore = 'vscode-logs-store'
+  const indexedDB = await IndexedDB.create('vscode-web-db', 3, [userDataStore, logsStore])
+
+  // Logger
+  providers[logsPath.scheme] = new IndexedDBFileSystemProvider(logsPath.scheme, indexedDB, logsStore, false)
+
+  const userDataProvider = new IndexedDBFileSystemProvider(Schemas.vscodeUserData, indexedDB, userDataStore, true)
+  providers[Schemas.vscodeUserData] = userDataProvider
 }
 
 /**

--- a/src/service-override/notifications.ts
+++ b/src/service-override/notifications.ts
@@ -31,9 +31,9 @@ onRenderWorkbench(async (accessor) => {
   })
 })
 
-export default function getServiceOverride (container?: HTMLElement): IEditorOverrideServices {
+export default function getServiceOverride (): IEditorOverrideServices {
   return {
     [INotificationService.toString()]: new SyncDescriptor(NotificationService, undefined, true),
-    ...getLayoutServiceOverride(container)
+    ...getLayoutServiceOverride()
   }
 }

--- a/src/service-override/output.ts
+++ b/src/service-override/output.ts
@@ -1,19 +1,28 @@
 import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
-import { URI } from 'vs/base/common/uri'
 import { IFileService } from 'vs/platform/files/common/files'
-import { ILoggerService, LogLevel } from 'vs/platform/log/common/log'
+import { ILoggerService, LogLevel, getLogLevel } from 'vs/platform/log/common/log'
 import { FileLoggerService } from 'vs/platform/log/common/fileLog'
 import 'vs/workbench/contrib/output/browser/output.contribution'
+import { IEnvironmentService } from 'vs/platform/environment/common/environment'
+import { logsPath } from '../workbench'
 
 class _FileLoggerService extends FileLoggerService {
-  constructor (logLevel: LogLevel, @IFileService fileService: IFileService) {
-    super(logLevel, URI.from({ scheme: 'logs', path: '/' }), fileService)
+  constructor (logLevel: LogLevel | undefined, @IFileService fileService: IFileService, @IEnvironmentService environmentService: IEnvironmentService) {
+    super(logLevel ?? getLogLevel(environmentService), logsPath, fileService)
   }
 }
 
-export default function getServiceOverride (logLevel: LogLevel = LogLevel.Info): IEditorOverrideServices {
+function getServiceOverride (): IEditorOverrideServices
+/**
+ * @deprecated Provide logLevel via the services `initialize` function `configuration.developmentOptions.logLevel` parameter
+ */
+function getServiceOverride (logLevel?: LogLevel): IEditorOverrideServices
+
+function getServiceOverride (logLevel?: LogLevel): IEditorOverrideServices {
   return {
     [ILoggerService.toString()]: new SyncDescriptor(_FileLoggerService, [logLevel], true)
   }
 }
+
+export default getServiceOverride

--- a/src/service-override/storage.ts
+++ b/src/service-override/storage.ts
@@ -9,8 +9,8 @@ import { IAnyWorkspaceIdentifier } from 'vs/platform/workspace/common/workspace'
 import { BrowserStorageService } from 'vs/workbench/services/storage/browser/storageService'
 import { ILogService } from 'vs/platform/log/common/log'
 import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile'
-import { generateUuid } from 'vs/base/common/uuid'
 import { registerServiceInitializePreParticipant } from '../lifecycle'
+import { getWorkspaceIdentifier } from '../workbench'
 
 export enum StorageScope {
   APPLICATION = VSStorageScope.APPLICATION,
@@ -138,9 +138,7 @@ class InjectedBrowserStorageService extends BrowserStorageService {
     @IUserDataProfileService userDataProfileService: IUserDataProfileService,
     @ILogService logService: ILogService
   ) {
-    super({
-      id: generateUuid()
-    }, userDataProfileService, logService)
+    super(getWorkspaceIdentifier(), userDataProfileService, logService)
   }
 }
 

--- a/src/service-override/storage.ts
+++ b/src/service-override/storage.ts
@@ -11,6 +11,7 @@ import { ILogService } from 'vs/platform/log/common/log'
 import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile'
 import { registerServiceInitializePreParticipant } from '../lifecycle'
 import { getWorkspaceIdentifier } from '../workbench'
+import { IHostService } from '../services'
 
 export enum StorageScope {
   APPLICATION = VSStorageScope.APPLICATION,
@@ -130,7 +131,17 @@ class ExternalStorageService extends AbstractStorageService {
 }
 
 registerServiceInitializePreParticipant(async (accessor) => {
-  await (accessor.get(IStorageService) as ExternalStorageService).initialize()
+  const storageService = accessor.get(IStorageService)
+  const hostService = accessor.get(IHostService)
+  if (storageService instanceof AbstractStorageService) {
+    await storageService.initialize()
+
+    hostService.onDidChangeFocus(focus => {
+      if (!focus) {
+        void storageService.flush()
+      }
+    })
+  }
 })
 
 class InjectedBrowserStorageService extends BrowserStorageService {

--- a/src/service-override/views.ts
+++ b/src/service-override/views.ts
@@ -54,7 +54,7 @@ import { IContextViewService } from 'vs/platform/contextview/browser/contextView
 import { ContextViewService } from 'vs/platform/contextview/browser/contextViewService'
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService'
 import { EditorInput, IEditorCloseHandler } from 'vs/workbench/common/editor/editorInput'
-import { EditorExtensions, EditorInputCapabilities, IEditorOpenContext, Verbosity } from 'vs/workbench/common/editor'
+import { EditorExtensions, EditorInputCapabilities, IEditorFactoryRegistry, IEditorOpenContext, IEditorSerializer, Verbosity } from 'vs/workbench/common/editor'
 import { IEditorOptions } from 'vs/platform/editor/common/editor'
 import { IResolvedTextEditorModel } from 'vs/editor/common/services/resolverService'
 import { ITextEditorService, TextEditorService } from 'vs/workbench/services/textfile/common/textEditorService'
@@ -368,6 +368,12 @@ function registerEditor (globPattern: string, editorInfo: RegisteredEditorInfo, 
       factory
     )
   })
+}
+
+function registerEditorSerializer<Services extends BrandedService[]> (editorTypeId: string, ctor: {
+  new (...Services: Services): IEditorSerializer
+}): IDisposable {
+  return Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEditorSerializer(editorTypeId, ctor)
 }
 
 interface CustomViewOption {
@@ -724,6 +730,8 @@ export {
   AbstractTextResourceEditorInput,
   EditorInput,
   registerEditor,
+  IEditorSerializer,
+  registerEditorSerializer,
   RegisteredEditorInfo,
   RegisteredEditorOptions,
   EditorInputFactoryObject,

--- a/src/service-override/views.ts
+++ b/src/service-override/views.ts
@@ -100,7 +100,7 @@ import getQuickAccessOverride from './quickaccess'
 import getKeybindingsOverride from './keybindings'
 import { changeUrlDomain } from './tools/url'
 import { registerAssets } from '../assets'
-import { registerServiceInitializePostParticipant } from '../lifecycle'
+import { onRenderWorkbench } from '../lifecycle'
 import { withReadyServices } from '../services'
 
 function createPart (id: string, role: string, classes: string[]): HTMLElement {
@@ -621,7 +621,7 @@ registerAssets({
 })
 
 let restoreEditorView = false
-registerServiceInitializePostParticipant(async (accessor) => {
+onRenderWorkbench(async (accessor) => {
   const paneCompositePartService = accessor.get(IPaneCompositePartService)
   const viewDescriptorService = accessor.get(IViewDescriptorService)
 

--- a/src/service-override/views.ts
+++ b/src/service-override/views.ts
@@ -630,8 +630,6 @@ onRenderWorkbench(async (accessor) => {
   const withBannerPart = accessor.get(IBannerService) instanceof Part
   const withTitlePart = accessor.get(ITitleService) instanceof Part
 
-  paneCompositePartService.getPaneComposites(ViewContainerLocation.Panel)
-
   const layoutService = accessor.get(ILayoutService) as LayoutService
 
   const invisibleContainer = document.createElement('div')

--- a/src/services.ts
+++ b/src/services.ts
@@ -31,7 +31,7 @@ export async function initialize (overrides: IEditorOverrideServices, container:
   initializeWorkbench(container, configuration)
 
   const instantiationService = StandaloneServices.initialize({
-    ...getLayoutServiceOverride(container), // Always override layout service to break cyclic dependency with ICodeEditorService
+    ...getLayoutServiceOverride(), // Always override layout service to break cyclic dependency with ICodeEditorService
     ...getEnvironmentServiceOverride(),
     ...getExtensionsServiceOverride(),
     ...getFileServiceOverride(),

--- a/src/services.ts
+++ b/src/services.ts
@@ -8,12 +8,14 @@ import { IEditorOverrideServices, StandaloneServices } from 'vs/editor/standalon
 import { GetLeadingNonServiceArgs, IInstantiationService, ServiceIdentifier, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation'
 import { IAction } from 'vs/base/common/actions'
 import { Disposable, DisposableStore, IDisposable } from 'vs/base/common/lifecycle'
+import { IWorkbenchConstructionOptions } from 'vs/workbench/browser/web.api'
 import getLayoutServiceOverride from './service-override/layout'
 import getEnvironmentServiceOverride from './service-override/environment'
 import getExtensionsServiceOverride from './service-override/extensions'
 import getFileServiceOverride from './service-override/files'
 import getQuickAccessOverride from './service-override/quickaccess'
 import { serviceInitializedBarrier, serviceInitializedEmitter, startup } from './lifecycle'
+import { initialize as initializeWorkbench } from './workbench'
 
 let servicesInitialized = false
 StandaloneServices.withServices(() => {
@@ -21,10 +23,13 @@ StandaloneServices.withServices(() => {
   return Disposable.None
 })
 
-export async function initialize (overrides: IEditorOverrideServices, container?: HTMLElement): Promise<void> {
+export async function initialize (overrides: IEditorOverrideServices, container: HTMLElement = document.body, configuration: IWorkbenchConstructionOptions = {}): Promise<void> {
   if (servicesInitialized) {
     throw new Error('The services are already initialized.')
   }
+
+  initializeWorkbench(container, configuration)
+
   const instantiationService = StandaloneServices.initialize({
     ...getLayoutServiceOverride(container), // Always override layout service to break cyclic dependency with ICodeEditorService
     ...getEnvironmentServiceOverride(),
@@ -248,5 +253,6 @@ export {
   IColorTheme,
   StorageScope,
   StorageTarget,
-  Severity
+  Severity,
+  IWorkbenchConstructionOptions
 }

--- a/src/workbench.ts
+++ b/src/workbench.ts
@@ -1,0 +1,51 @@
+import './missing-services'
+import { IAnyWorkspaceIdentifier, UNKNOWN_EMPTY_WINDOW_WORKSPACE } from 'vs/platform/workspace/common/workspace'
+import { IWorkspace } from 'vs/workbench/services/host/browser/browserHostService'
+import { IWorkbenchConstructionOptions } from 'vs/workbench/browser/web.api'
+import { isFolderToOpen, isWorkspaceToOpen } from 'vs/platform/window/common/window'
+import { getSingleFolderWorkspaceIdentifier, getWorkspaceIdentifier as getWorkspaceIdentifierFromUri } from 'vs/workbench/services/workspaces/browser/workspaces'
+import { URI } from 'vs/base/common/uri'
+import { toLocalISOString } from 'vs/base/common/date'
+
+let workbenchContainer: HTMLElement = document.body
+let workbenchConstructionOptions: IWorkbenchConstructionOptions = {}
+let workspaceIdentifier: IAnyWorkspaceIdentifier = UNKNOWN_EMPTY_WINDOW_WORKSPACE
+export const logsPath = URI.file(toLocalISOString(new Date()).replace(/-|:|\.\d+Z$/g, '')).with({ scheme: 'vscode-log' })
+
+export function getWorkbenchContainer (): HTMLElement {
+  return workbenchContainer
+}
+
+export function getWorkbenchConstructionOptions (): IWorkbenchConstructionOptions {
+  return workbenchConstructionOptions
+}
+
+export function getWorkspaceIdentifier (): IAnyWorkspaceIdentifier {
+  return workspaceIdentifier
+}
+
+function resolveWorkspace (configuration: IWorkbenchConstructionOptions): IAnyWorkspaceIdentifier {
+  let workspace: IWorkspace | undefined
+  if (configuration.workspaceProvider != null) {
+    workspace = configuration.workspaceProvider.workspace
+  }
+
+  // Multi-root workspace
+  if (workspace != null && isWorkspaceToOpen(workspace)) {
+    return getWorkspaceIdentifierFromUri(workspace.workspaceUri)
+  }
+
+  // Single-folder workspace
+  if (workspace != null && isFolderToOpen(workspace)) {
+    return getSingleFolderWorkspaceIdentifier(workspace.folderUri)
+  }
+
+  // Empty window workspace
+  return UNKNOWN_EMPTY_WINDOW_WORKSPACE
+}
+
+export function initialize (container: HTMLElement, options: IWorkbenchConstructionOptions): void {
+  workbenchContainer = container
+  workbenchConstructionOptions = options
+  workspaceIdentifier = resolveWorkspace(options)
+}


### PR DESCRIPTION
What this PR does:
- It changes the way services overrides are configured, using the VSCode `IWorkbenchConstructionOptions` type to configure them all at once. It allows to configure things that are now hardcoded (with a wrong value sometimes).
- It removes most service-override parameters that are an issue because some service-override includes others and it may override previous given parameters, leading to unpredictable behaviors
- It fixes the json intellisense not working anymore on settings/keybindings after recent path changes (to match those in VSCode)
- it fixes editor serialization (2 bugs: 57573dbb9daac7c6e60cfc8f4df2b7301be9336b and 0cf513040b59ffcef5a17f7104cd86d1125f77af and a way to register a custom one 7565dc32418d3f68bedd1e9c712afe50fcb4ed80) (@CompuIves)
- it allows to easily use IndexedDB fs provider for user files

It changes the recommended api but there is no breaking changes, only some method parameters marked as deprecated