### PR TITLE
fix(vsix-plugin): set mime type in dev mode

### DIFF
--- a/src/rollup-vsix-plugin.ts
+++ b/src/rollup-vsix-plugin.ts
@@ -101,7 +101,8 @@ export default function plugin ({
         const assetPath = getVsixPath(resource.realPath ?? resource.path)
         let url: string
         if (process.env.NODE_ENV === 'development') {
-          url = `'data:text/javascript;base64,${readFileSync(assetPath).toString('base64')}'`
+          const fileType = resource.mimeType ?? 'text/javascript'
+          url = `'data:${fileType};base64,${readFileSync(assetPath).toString('base64')}'`
         } else {
           url = 'import.meta.ROLLUP_FILE_URL_' + this.emitFile({
             type: 'asset',


### PR DESCRIPTION
In dev mode the mime type of the base64 string is hardcoded to `text/javascript`. This works for most files, but it won't work for e.g. file icons, which are svg. In that case, it will not render anything:
<img width="725" alt="image" src="https://github.com/CodinGame/monaco-vscode-api/assets/587016/ed1b10a7-2781-4978-96a5-4641d5b704a7">

With this change, we use the inferred mime type for the base64. Now the main question is... Will this work for all file types?