### PR TITLE
feat: add extension url and authentication service

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@codingame/monaco-vscode-accessibility-service-override": "file:../dist/service-override-accessibility",
         "@codingame/monaco-vscode-audio-cue-service-override": "file:../dist/service-override-audio-cue",
+        "@codingame/monaco-vscode-authentication-service-override": "file:../dist/service-override-authentication",
         "@codingame/monaco-vscode-bat-default-extension": "file:../dist/default-extension-bat",
         "@codingame/monaco-vscode-bulk-edit-service-override": "file:../dist/service-override-bulk-edit",
         "@codingame/monaco-vscode-clojure-default-extension": "file:../dist/default-extension-clojure",
@@ -944,6 +945,15 @@
         "vscode": "npm:@codingame/monaco-vscode-api@^0.0.0-semantic-release"
       }
     },
+    "../dist/service-override-authentication": {
+      "name": "@codingame/monaco-vscode-authentication-service-override",
+      "version": "0.0.0-semantic-release",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-editor": "0.44.0",
+        "vscode": "npm:@codingame/monaco-vscode-api@^0.0.0-semantic-release"
+      }
+    },
     "../dist/service-override-bulk-edit": {
       "name": "@codingame/monaco-vscode-bulk-edit-service-override",
       "version": "0.0.0-semantic-release",
@@ -1415,6 +1425,10 @@
     },
     "node_modules/@codingame/monaco-vscode-audio-cue-service-override": {
       "resolved": "../dist/service-override-audio-cue",
+      "link": true
+    },
+    "node_modules/@codingame/monaco-vscode-authentication-service-override": {
+      "resolved": "../dist/service-override-authentication",
       "link": true
     },
     "node_modules/@codingame/monaco-vscode-bat-default-extension": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -29,6 +29,7 @@
     "@codingame/monaco-vscode-log-service-override": "file:../dist/service-override-log",
     "@codingame/monaco-vscode-accessibility-service-override": "file:../dist/service-override-accessibility",
     "@codingame/monaco-vscode-audio-cue-service-override": "file:../dist/service-override-audio-cue",
+    "@codingame/monaco-vscode-authentication-service-override": "file:../dist/service-override-authentication",
     "@codingame/monaco-vscode-bat-default-extension": "file:../dist/default-extension-bat",
     "@codingame/monaco-vscode-bulk-edit-service-override": "file:../dist/service-override-bulk-edit",
     "@codingame/monaco-vscode-clojure-default-extension": "file:../dist/default-extension-clojure",

--- a/demo/src/setup.ts
+++ b/demo/src/setup.ts
@@ -8,6 +8,7 @@ import getKeybindingsServiceOverride, { initUserKeybindings } from '@codingame/m
 import getTextmateServiceOverride from '@codingame/monaco-vscode-textmate-service-override'
 import getThemeServiceOverride from '@codingame/monaco-vscode-theme-service-override'
 import getLanguagesServiceOverride from '@codingame/monaco-vscode-languages-service-override'
+import getAuthenticationServiceOverride from '@codingame/monaco-vscode-authentication-service-override'
 import getAudioCueServiceOverride from '@codingame/monaco-vscode-audio-cue-service-override'
 import getExtensionGalleryServiceOverride from '@codingame/monaco-vscode-extension-gallery-service-override'
 import getViewsServiceOverride, {
@@ -92,6 +93,7 @@ await Promise.all([
 
 // Override services
 await initializeMonacoService({
+  ...getAuthenticationServiceOverride(),
   ...getLogServiceOverride(),
   ...getExtensionServiceOverride(workerConfig),
   ...getExtensionGalleryServiceOverride({ webOnly: false }),

--- a/scripts/vscode.patch
+++ b/scripts/vscode.patch
@@ -1880,6 +1880,19 @@ index 25885c7c4f9..2d220cbe1ad 100644
 +
 +
 +registerSingleton(IExtensionService, BrowserExtensionService, InstantiationType.Eager);
+diff --git a/src/vs/workbench/services/extensions/browser/extensionUrlHandler.ts b/src/vs/workbench/services/extensions/browser/extensionUrlHandler.ts
+index 9da3a6e5c58..dce278df3bb 100644
+--- a/src/vs/workbench/services/extensions/browser/extensionUrlHandler.ts
++++ b/src/vs/workbench/services/extensions/browser/extensionUrlHandler.ts
+@@ -99,7 +99,7 @@ type ExtensionUrlHandlerClassification = {
+  *
+  * It also makes sure the user confirms opening URLs directed towards extensions.
+  */
+-class ExtensionUrlHandler implements IExtensionUrlHandler, IURLHandler {
++export class ExtensionUrlHandler implements IExtensionUrlHandler, IURLHandler {
+ 
+ 	readonly _serviceBrand: undefined;
+ 
 diff --git a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
 index a7ce017ab9f..fd873470224 100644
 --- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts

--- a/src/service-override/authentication.ts
+++ b/src/service-override/authentication.ts
@@ -1,0 +1,10 @@
+import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
+import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
+import { IAuthenticationService } from 'vs/workbench/services/authentication/common/authentication'
+import { AuthenticationService } from 'vs/workbench/services/authentication/browser/authenticationService'
+
+export default function getServiceOverride (): IEditorOverrideServices {
+  return {
+    [IAuthenticationService.toString()]: new SyncDescriptor(AuthenticationService, [], true)
+  }
+}

--- a/src/service-override/extensionGallery.ts
+++ b/src/service-override/extensionGallery.ts
@@ -24,9 +24,10 @@ import { ExtensionTipsService } from 'vs/platform/extensionManagement/common/ext
 import { ExtensionManagementService } from 'vs/workbench/services/extensionManagement/common/extensionManagementService'
 import { IRemoteUserDataProfilesService, RemoteUserDataProfilesService } from 'vs/workbench/services/userDataProfile/common/remoteUserDataProfiles'
 import { ExtensionEnablementService } from 'vs/workbench/services/extensionManagement/browser/extensionEnablementService'
-import { IInstantiationService, ILabelService, IRemoteAgentService } from '../services'
 import 'vs/workbench/contrib/extensions/browser/extensions.contribution'
 import 'vs/workbench/contrib/extensions/browser/extensions.web.contribution'
+import { ExtensionUrlHandler, IExtensionUrlHandler } from 'vs/workbench/services/extensions/browser/extensionUrlHandler'
+import { IInstantiationService, ILabelService, IRemoteAgentService } from '../services'
 import { registerAssets } from '../assets'
 
 // plugin-import-meta-asset only allows relative paths
@@ -82,6 +83,7 @@ export default function getServiceOverride (options: ExtensionGalleryOptions = {
     [IRemoteExtensionsScannerService.toString()]: new SyncDescriptor(RemoteExtensionsScannerService, [], true),
     [IExtensionTipsService.toString()]: new SyncDescriptor(ExtensionTipsService, [], true),
     [IRemoteUserDataProfilesService.toString()]: new SyncDescriptor(RemoteUserDataProfilesService, [], true),
-    [IWorkbenchExtensionEnablementService.toString()]: new SyncDescriptor(ExtensionEnablementService, [], true)
+    [IWorkbenchExtensionEnablementService.toString()]: new SyncDescriptor(ExtensionEnablementService, [], true),
+    [IExtensionUrlHandler.toString()]: new SyncDescriptor(ExtensionUrlHandler, [], true)
   }
 }


### PR DESCRIPTION
We need these ones to support the "GitHub Pull Requests and Issues" extension from the marketplace (which would be insane if we could support that!)

Keep in mind that this in of itself would not be enough, the user would have to implement the GitHub authentication manually by overriding the github authentication extension manually. But that's everything needed!