### PR TITLE
fix: ensure that local change commands are registered

### DIFF
--- a/rollup/rollup.config.ts
+++ b/rollup/rollup.config.ts
@@ -89,7 +89,9 @@ const REMOVE_COMMANDS = new Set([
   'debug.startFromConfig',
   'debug.installAdditionalDebuggers',
   'REMOVE_ROOT_FOLDER_COMMAND_ID',
-  'debug.openView'
+  'debug.openView',
+  '_files.windowOpen',
+  '_files.newWindow'
 ])
 
 const KEEP_COLORS = new Set([
@@ -159,8 +161,14 @@ function isCallPure (file: string, functionName: string, node: recast.types.name
   }
 
   if (functionName === 'CommandsRegistry.registerCommand') {
-    if (file.includes('fileActions.contribution') || file.includes('workspaceCommands') || file.includes('mainThreadCLICommands')) {
+    if (file.includes('workspaceCommands') || file.includes('mainThreadCLICommands')) {
       return true
+    }
+
+    const firstParam = args[0]!
+    if (firstParam.type === 'StringLiteral') {
+      const commandId = firstParam.value
+      return REMOVE_COMMANDS.has(commandId)
     }
   }
 


### PR DESCRIPTION
The commands `workbench.files.action.acceptLocalChanges` and `workbench.files.action.revertLocalChanges` were not registered because all the `CommandsRegistry.registerCommand` calls were tree-shaken out for the file where they were registered. I think that was introduced to shake `_files.windowOpen` and `_files.newWindow` out, so I've changed it so that the commands are shaken out explicitly instead of shaking out the whole file.