### PR TITLE
a few minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,10 +192,12 @@ Additionally, several packages that include the VSCode version of some services 
   - Support for the VSCode marketplace, it allows to install extensions from the marketplace.
 - **Chat**: `@codingame/monaco-vscode-chat-service-override`
   - Support for chat and inline chat features
-- **Notebook**
+- **Notebook**: `@codingame/monaco-vscode-notebook-service-override`
   - Support for Jupyter notebooks
-- **Welcome**
+- **Welcome**: `@codingame/monaco-vscode-welcome-service-override`
   - Support for welcome pages/components. *Hint*: It only makes sense to enable it when *Views* service is used.
+- **User data sync**: `@codingame/monaco-vscode-user-data-sync-service-override`
+  - Support for user data sync. ⚠️ It can't really be used as it relies on a [closed source backend from microsoft](https://code.visualstudio.com/docs/editor/settings-sync#_can-i-use-a-different-backend-or-service-for-settings-sync) for the moment ⚠️
 
 Usage:
 

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -141,6 +141,7 @@
         "@codingame/monaco-vscode-theme-tomorrow-night-blue-default-extension": "file:../dist/default-extension-theme-tomorrow-night-blue",
         "@codingame/monaco-vscode-typescript-basics-default-extension": "file:../dist/default-extension-typescript-basics",
         "@codingame/monaco-vscode-typescript-language-features-default-extension": "file:../dist/default-extension-typescript-language-features",
+        "@codingame/monaco-vscode-user-data-sync-service-override": "file:../dist/service-override-user-data-sync",
         "@codingame/monaco-vscode-vb-default-extension": "file:../dist/default-extension-vb",
         "@codingame/monaco-vscode-view-banner-service-override": "file:../dist/service-override-view-banner",
         "@codingame/monaco-vscode-view-status-bar-service-override": "file:../dist/service-override-view-status-bar",
@@ -1284,6 +1285,15 @@
         "vscode": "npm:@codingame/monaco-vscode-api@^0.0.0-semantic-release"
       }
     },
+    "../dist/service-override-user-data-sync": {
+      "name": "@codingame/monaco-vscode-user-data-sync-service-override",
+      "version": "0.0.0-semantic-release",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-editor": "0.45.0",
+        "vscode": "npm:@codingame/monaco-vscode-api@^0.0.0-semantic-release"
+      }
+    },
     "../dist/service-override-view-banner": {
       "name": "@codingame/monaco-vscode-view-banner-service-override",
       "version": "0.0.0-semantic-release",
@@ -2002,6 +2012,10 @@
     },
     "node_modules/@codingame/monaco-vscode-typescript-language-features-default-extension": {
       "resolved": "../dist/default-extension-typescript-language-features",
+      "link": true
+    },
+    "node_modules/@codingame/monaco-vscode-user-data-sync-service-override": {
+      "resolved": "../dist/service-override-user-data-sync",
       "link": true
     },
     "node_modules/@codingame/monaco-vscode-vb-default-extension": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -171,6 +171,7 @@
     "@codingame/monaco-vscode-xml-default-extension": "file:../dist/default-extension-xml",
     "@codingame/monaco-vscode-yaml-default-extension": "file:../dist/default-extension-yaml",
     "@codingame/monaco-vscode-welcome-service-override": "file:../dist/service-override-welcome",
+    "@codingame/monaco-vscode-user-data-sync-service-override": "file:../dist/service-override-user-data-sync",
     "ansi-colors": "^4.1.3",
     "dockerode": "^4.0.0",
     "express": "^4.18.2",

--- a/demo/src/setup.ts
+++ b/demo/src/setup.ts
@@ -47,6 +47,7 @@ import getTestingServiceOverride from '@codingame/monaco-vscode-testing-service-
 import getChatServiceOverride from '@codingame/monaco-vscode-chat-service-override'
 import getNotebookServiceOverride from '@codingame/monaco-vscode-notebook-service-override'
 import getWelcomeServiceOverride from '@codingame/monaco-vscode-welcome-service-override'
+import getUserDataSyncServiceOverride from '@codingame/monaco-vscode-user-data-sync-service-override'
 import * as monaco from 'monaco-editor'
 import { registerExtension } from 'vscode/extensions'
 import { TerminalBackend } from './features/terminal'
@@ -150,7 +151,8 @@ await initializeMonacoService({
   ...getTestingServiceOverride(),
   ...getChatServiceOverride(),
   ...getNotebookServiceOverride(),
-  ...getWelcomeServiceOverride()
+  ...getWelcomeServiceOverride(),
+  ...getUserDataSyncServiceOverride()
 }, document.body, {
   remoteAuthority,
   enableWorkspaceTrust: true,

--- a/scripts/vscode.patch
+++ b/scripts/vscode.patch
@@ -2325,6 +2325,19 @@ index 94a4879c2f9..b58e3ffb222 100644
  }
  
  export class WalkThroughSnippetContentProvider implements ITextModelContentProvider, IWorkbenchContribution {
+diff --git a/src/vs/workbench/services/extensionManagement/browser/extensionBisect.ts b/src/vs/workbench/services/extensionManagement/browser/extensionBisect.ts
+index 1029b67197d..2ee4f0db240 100644
+--- a/src/vs/workbench/services/extensionManagement/browser/extensionBisect.ts
++++ b/src/vs/workbench/services/extensionManagement/browser/extensionBisect.ts
+@@ -65,7 +65,7 @@ class BisectState {
+ 	) { }
+ }
+ 
+-class ExtensionBisectService implements IExtensionBisectService {
++export class ExtensionBisectService implements IExtensionBisectService {
+ 
+ 	declare readonly _serviceBrand: undefined;
+ 
 diff --git a/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts b/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
 index 362e485948a..50f5a5f175d 100644
 --- a/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
@@ -2968,6 +2981,19 @@ index d3ef612836b..0d0fb8d2862 100644
 +export class RemoteUserDataProfilesService extends Disposable implements IRemoteUserDataProfilesService {
  
  	readonly _serviceBrand: undefined;
+ 
+diff --git a/src/vs/workbench/services/userDataSync/common/userDataSyncUtil.ts b/src/vs/workbench/services/userDataSync/common/userDataSyncUtil.ts
+index 45329df40c4..84119b7c042 100644
+--- a/src/vs/workbench/services/userDataSync/common/userDataSyncUtil.ts
++++ b/src/vs/workbench/services/userDataSync/common/userDataSyncUtil.ts
+@@ -12,7 +12,7 @@ import { URI } from 'vs/base/common/uri';
+ import { ITextModelService } from 'vs/editor/common/services/resolverService';
+ import { ITextResourcePropertiesService, ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
+ 
+-class UserDataSyncUtilService implements IUserDataSyncUtilService {
++export class UserDataSyncUtilService implements IUserDataSyncUtilService {
+ 
+ 	declare readonly _serviceBrand: undefined;
  
 diff --git a/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts b/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts
 index 4653e395be9..1eccfce4bf4 100644

--- a/src/missing-services.ts
+++ b/src/missing-services.ts
@@ -101,7 +101,7 @@ import { IEnvironmentVariableService } from 'vs/workbench/contrib/terminal/commo
 import { ITerminalQuickFixService } from 'vs/workbench/contrib/terminalContrib/quickFix/browser/quickFix'
 import { IPreferencesSearchService } from 'vs/workbench/contrib/preferences/common/preferences'
 import { AccountStatus, IUserDataSyncWorkbenchService } from 'vs/workbench/services/userDataSync/common/userDataSync'
-import { IUserDataAutoSyncService, IUserDataSyncEnablementService } from 'vs/platform/userDataSync/common/userDataSync'
+import { IUserDataAutoSyncService, IUserDataSyncEnablementService, IUserDataSyncLocalStoreService, IUserDataSyncLogService, IUserDataSyncResourceProviderService, IUserDataSyncService, IUserDataSyncStoreManagementService, IUserDataSyncStoreService, IUserDataSyncUtilService, SyncStatus } from 'vs/platform/userDataSync/common/userDataSync'
 import { IKeybindingEditingService } from 'vs/workbench/services/keybinding/common/keybindingEditing'
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService'
 import { ISearchHistoryService } from 'vs/workbench/contrib/search/common/searchHistoryService'
@@ -193,8 +193,9 @@ import { INotebookLoggingService } from 'vs/workbench/contrib/notebook/common/no
 import { IInlineChatSessionService } from 'vs/workbench/contrib/inlineChat/browser/inlineChatSession'
 import { IWalkthroughsService } from 'vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService'
 import { IFeaturedExtensionsService } from 'vs/workbench/contrib/welcomeGettingStarted/browser/featuredExtensionService'
-import { getBuiltInExtensionTranslationsUris } from './l10n'
+import { IUserDataSyncMachinesService } from 'vs/platform/userDataSync/common/userDataSyncMachines'
 import { unsupported } from './tools'
+import { getBuiltInExtensionTranslationsUris } from './l10n'
 
 class NullLoggerService extends AbstractLoggerService {
   constructor () {
@@ -2710,4 +2711,110 @@ registerSingleton(IFeaturedExtensionsService, class FeaturedExtensionsService im
   get title () {
     return unsupported()
   }
+}, InstantiationType.Delayed)
+
+registerSingleton(IUserDataSyncStoreManagementService, class UserDataSyncStoreManagementService implements IUserDataSyncStoreManagementService {
+  _serviceBrand: undefined
+  onDidChangeUserDataSyncStore = Event.None
+  userDataSyncStore = undefined
+  switch = unsupported
+  getPreviousUserDataSyncStore = unsupported
+}, InstantiationType.Delayed)
+
+registerSingleton(IUserDataSyncStoreService, class UserDataSyncStoreService implements IUserDataSyncStoreService {
+  _serviceBrand: undefined
+  onDidChangeDonotMakeRequestsUntil = Event.None
+  donotMakeRequestsUntil = undefined
+  onTokenFailed = Event.None
+  onTokenSucceed = Event.None
+  setAuthToken = unsupported
+  manifest = unsupported
+  readResource = unsupported
+  writeResource = unsupported
+  deleteResource = unsupported
+  getAllResourceRefs = unsupported
+  resolveResourceContent = unsupported
+  getAllCollections = unsupported
+  createCollection = unsupported
+  deleteCollection = unsupported
+  getActivityData = unsupported
+  clear = unsupported
+}, InstantiationType.Delayed)
+
+registerSingleton(IUserDataSyncLogService, class UserDataSyncLogService implements IUserDataSyncLogService {
+  _serviceBrand: undefined
+  onDidChangeLogLevel = Event.None
+  getLevel = unsupported
+  setLevel = unsupported
+  trace = unsupported
+  debug = unsupported
+  info = unsupported
+  warn = unsupported
+  error = unsupported
+  flush = unsupported
+  dispose = unsupported
+}, InstantiationType.Delayed)
+
+registerSingleton(IUserDataSyncService, class UserDataSyncService implements IUserDataSyncService {
+  _serviceBrand: undefined
+  status = SyncStatus.Uninitialized
+  onDidChangeStatus = Event.None
+  conflicts = []
+  onDidChangeConflicts = Event.None
+  onDidChangeLocal = Event.None
+  onSyncErrors = Event.None
+  lastSyncTime: number | undefined
+  onDidChangeLastSyncTime = Event.None
+  onDidResetRemote = Event.None
+  onDidResetLocal = Event.None
+  createSyncTask = unsupported
+  createManualSyncTask = unsupported
+  resolveContent = unsupported
+  accept = unsupported
+  reset = unsupported
+  resetRemote = unsupported
+  cleanUpRemoteData = unsupported
+  resetLocal = unsupported
+  hasLocalData = unsupported
+  hasPreviouslySynced = unsupported
+  replace = unsupported
+  saveRemoteActivityData = unsupported
+  extractActivityData = unsupported
+}, InstantiationType.Delayed)
+
+registerSingleton(IUserDataSyncMachinesService, class UserDataSyncMachinesService implements IUserDataSyncMachinesService {
+  _serviceBrand: undefined
+  onDidChange = Event.None
+  getMachines = unsupported
+  addCurrentMachine = unsupported
+  removeCurrentMachine = unsupported
+  renameMachine = unsupported
+  setEnablements = unsupported
+}, InstantiationType.Delayed)
+
+registerSingleton(IUserDataSyncResourceProviderService, class UserDataSyncResourceProviderService implements IUserDataSyncResourceProviderService {
+  _serviceBrand: undefined
+  getRemoteSyncedProfiles = unsupported
+  getLocalSyncedProfiles = unsupported
+  getRemoteSyncResourceHandles = unsupported
+  getLocalSyncResourceHandles = unsupported
+  getAssociatedResources = unsupported
+  getMachineId = unsupported
+  getLocalSyncedMachines = unsupported
+  resolveContent = unsupported
+  resolveUserDataSyncResource = unsupported
+}, InstantiationType.Delayed)
+
+registerSingleton(IUserDataSyncLocalStoreService, class UserDataSyncLocalStoreService implements IUserDataSyncLocalStoreService {
+  _serviceBrand: undefined
+  writeResource = unsupported
+  getAllResourceRefs = unsupported
+  resolveResourceContent = unsupported
+}, InstantiationType.Delayed)
+
+registerSingleton(IUserDataSyncUtilService, class UserDataSyncUtilService implements IUserDataSyncUtilService {
+  _serviceBrand: undefined
+  resolveUserBindings = unsupported
+  resolveFormattingOptions = unsupported
+  resolveDefaultIgnoredSettings = unsupported
 }, InstantiationType.Delayed)

--- a/src/service-override/extensions.ts
+++ b/src/service-override/extensions.ts
@@ -38,6 +38,7 @@ import { IRemoteExplorerService } from 'vs/workbench/services/remote/common/remo
 import { ExtensionDescriptionRegistrySnapshot } from 'vs/workbench/services/extensions/common/extensionDescriptionRegistry'
 import { ExtensionResourceLoaderService } from 'vs/platform/extensionResourceLoader/browser/extensionResourceLoaderService'
 import { IExtensionResourceLoaderService } from 'vs/platform/extensionResourceLoader/common/extensionResourceLoader'
+import { ExtensionBisectService, IExtensionBisectService } from 'vs/workbench/services/extensionManagement/browser/extensionBisect'
 import { changeUrlDomain } from './tools/url'
 import { CustomSchemas } from './files'
 import type { LocalExtensionHost } from '../localExtensionHost'
@@ -285,7 +286,8 @@ export default function getServiceOverride (workerConfig?: WorkerConfig, _iframe
   return {
     [IExtensionService.toString()]: new SyncDescriptor(ExtensionServiceOverride, [_workerConfig], false),
     [IExtensionManifestPropertiesService.toString()]: new SyncDescriptor(ExtensionManifestPropertiesService, [], true),
-    [IExtensionResourceLoaderService.toString()]: new SyncDescriptor(ExtensionResourceLoaderServiceOverride, [], true)
+    [IExtensionResourceLoaderService.toString()]: new SyncDescriptor(ExtensionResourceLoaderServiceOverride, [], true),
+    [IExtensionBisectService.toString()]: new SyncDescriptor(ExtensionBisectService, [], true)
   }
 }
 

--- a/src/service-override/tools/editor.ts
+++ b/src/service-override/tools/editor.ts
@@ -531,7 +531,7 @@ export class MonacoDelegateEditorGroupsService<D extends IEditorGroupsService> e
   }
 
   getGroups: IEditorGroupsService['getGroups'] = (order) => {
-    return [...this.additionalGroups, ...this.delegate.getGroups(order)]
+    return [...this.delegate.getGroups(order), ...this.additionalGroups]
   }
 
   getGroup: IEditorGroupsService['getGroup'] = (identifier) => {

--- a/src/service-override/userDataSync.ts
+++ b/src/service-override/userDataSync.ts
@@ -1,0 +1,111 @@
+import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
+import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
+import { IUserDataAutoSyncService, IUserDataSyncEnablementService, IUserDataSyncLocalStoreService, IUserDataSyncLogService, IUserDataSyncResourceProviderService, IUserDataSyncService, IUserDataSyncStoreManagementService, IUserDataSyncStoreService, IUserDataSyncUtilService } from 'vs/platform/userDataSync/common/userDataSync'
+import { IUserDataSyncAccountService, UserDataSyncAccountService } from 'vs/platform/userDataSync/common/userDataSyncAccount'
+import { IUserDataSyncMachinesService, UserDataSyncMachinesService } from 'vs/platform/userDataSync/common/userDataSyncMachines'
+import { UserDataSyncStoreManagementService, UserDataSyncStoreService } from 'vs/platform/userDataSync/common/userDataSyncStoreService'
+import { UserDataAutoSyncService } from 'vs/platform/userDataSync/common/userDataAutoSyncService'
+import { WebUserDataSyncEnablementService } from 'vs/workbench/services/userDataSync/browser/webUserDataSyncEnablementService'
+import { UserDataSyncService } from 'vs/platform/userDataSync/common/userDataSyncService'
+import { UserDataSyncLogService } from 'vs/platform/userDataSync/common/userDataSyncLog'
+import { BrowserUserDataProfilesService } from 'vs/platform/userDataProfile/browser/userDataProfile'
+import { IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile'
+import { UserDataSyncResourceProviderService } from 'vs/platform/userDataSync/common/userDataSyncResourceProvider'
+import { UserDataSyncLocalStoreService } from 'vs/platform/userDataSync/common/userDataSyncLocalStoreService'
+import { UserDataSyncWorkbenchService } from 'vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService'
+import { IUserDataSyncWorkbenchService } from 'vs/workbench/services/userDataSync/common/userDataSync'
+import 'vs/workbench/contrib/userDataSync/browser/userDataSync.contribution'
+import { IUserDataInitializationService, IUserDataInitializer, UserDataInitializationService } from 'vs/workbench/services/userData/browser/userDataInit'
+import { UserDataSyncInitializer } from 'vs/workbench/services/userDataSync/browser/userDataSyncInit'
+import { UserDataProfileInitializer } from 'vs/workbench/services/userDataProfile/browser/userDataProfileInit'
+import { IBrowserWorkbenchEnvironmentService } from 'vs/workbench/services/environment/browser/environmentService'
+import { ISecretStorageService } from 'vs/platform/secrets/common/secrets'
+import { IFileService } from 'vs/platform/files/common/files'
+import { IStorageService } from 'vs/platform/storage/common/storage'
+import { IProductService } from 'vs/platform/product/common/productService'
+import { IRequestService } from 'vs/platform/request/common/request'
+import { ILogService } from 'vs/platform/log/common/log'
+import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity'
+import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile'
+import { mark } from 'vs/base/common/performance'
+import type { WorkspaceService } from 'vs/workbench/services/configuration/browser/configurationService'
+import { timeout } from 'vs/base/common/async'
+import { IWorkbenchConfigurationService } from 'vs/workbench/services/configuration/common/configuration'
+import { UserDataSyncUtilService } from 'vs/workbench/services/userDataSync/common/userDataSyncUtil'
+import { registerServiceInitializePostParticipant } from '../lifecycle'
+
+function isWorkspaceService (configurationService: IWorkbenchConfigurationService): configurationService is WorkspaceService {
+  return 'reloadLocalUserConfiguration' in configurationService
+}
+
+async function initializeUserData (userDataInitializationService: UserDataInitializationService, configurationService: IWorkbenchConfigurationService) {
+  if (await userDataInitializationService.requiresInitialization()) {
+    mark('code/willInitRequiredUserData')
+
+    // Initialize required resources - settings & global state
+    await userDataInitializationService.initializeRequiredResources()
+
+    // Important: Reload only local user configuration after initializing
+    // Reloading complete configuration blocks workbench until remote configuration is loaded.
+    if (isWorkspaceService(configurationService)) {
+      await configurationService.reloadLocalUserConfiguration()
+    }
+
+    mark('code/didInitRequiredUserData')
+  }
+}
+
+registerServiceInitializePostParticipant(async accessor => {
+  try {
+    await Promise.race([
+      // Do not block more than 5s
+      timeout(5000),
+      initializeUserData(accessor.get(IUserDataInitializationService) as UserDataInitializationService, accessor.get(IWorkbenchConfigurationService))]
+    )
+  } catch (error) {
+    accessor.get(ILogService).error(error as Error)
+  }
+})
+
+class InjectedUserDataInitializationService extends UserDataInitializationService {
+  constructor (
+    @IBrowserWorkbenchEnvironmentService environmentService: IBrowserWorkbenchEnvironmentService,
+    @ISecretStorageService secretStorageService: ISecretStorageService,
+    @IUserDataSyncStoreManagementService userDataSyncStoreManagementService: IUserDataSyncStoreManagementService,
+    @IFileService fileService: IFileService,
+    @IUserDataProfilesService userDataProfilesService: IUserDataProfilesService,
+    @IStorageService storageService: IStorageService,
+    @IProductService productService: IProductService,
+    @IRequestService requestService: IRequestService,
+    @ILogService logService: ILogService,
+    @IUriIdentityService uriIdentityService: IUriIdentityService,
+    @IUserDataProfileService userDataProfileService: IUserDataProfileService
+  ) {
+    const userDataInitializers: IUserDataInitializer[] = []
+    userDataInitializers.push(new UserDataSyncInitializer(environmentService, secretStorageService, userDataSyncStoreManagementService, fileService, userDataProfilesService, storageService, productService, requestService, logService, uriIdentityService))
+    if (environmentService.options?.profile != null) {
+      userDataInitializers.push(new UserDataProfileInitializer(environmentService, fileService, userDataProfileService, storageService, logService, uriIdentityService, requestService))
+    }
+
+    super(userDataInitializers)
+  }
+}
+
+export default function getServiceOverride (): IEditorOverrideServices {
+  return {
+    [IUserDataAutoSyncService.toString()]: new SyncDescriptor(UserDataAutoSyncService, [], true),
+    [IUserDataSyncStoreManagementService.toString()]: new SyncDescriptor(UserDataSyncStoreManagementService, [], true),
+    [IUserDataSyncStoreService.toString()]: new SyncDescriptor(UserDataSyncStoreService, [], true),
+    [IUserDataSyncEnablementService.toString()]: new SyncDescriptor(WebUserDataSyncEnablementService, [], true),
+    [IUserDataSyncService.toString()]: new SyncDescriptor(UserDataSyncService, [], true),
+    [IUserDataSyncLogService.toString()]: new SyncDescriptor(UserDataSyncLogService, [], true),
+    [IUserDataSyncAccountService.toString()]: new SyncDescriptor(UserDataSyncAccountService, [], true),
+    [IUserDataSyncMachinesService.toString()]: new SyncDescriptor(UserDataSyncMachinesService, [], true),
+    [IUserDataProfilesService.toString()]: new SyncDescriptor(BrowserUserDataProfilesService, [], true),
+    [IUserDataSyncResourceProviderService.toString()]: new SyncDescriptor(UserDataSyncResourceProviderService, [], true),
+    [IUserDataSyncLocalStoreService.toString()]: new SyncDescriptor(UserDataSyncLocalStoreService, [], true),
+    [IUserDataSyncWorkbenchService.toString()]: new SyncDescriptor(UserDataSyncWorkbenchService, [], true),
+    [IUserDataInitializationService.toString()]: new SyncDescriptor(InjectedUserDataInitializationService, [], true),
+    [IUserDataSyncUtilService.toString()]: new SyncDescriptor(UserDataSyncUtilService, [], true)
+  }
+}


### PR DESCRIPTION
A few minor fixes

The user data sync service override is not usable for the moment at it relies on a closed-source server hosted behing `https://vscode-sync.trafficmanager.net/`. But it may be useful in the future (see https://code.visualstudio.com/docs/editor/settings-sync#_can-i-use-a-different-backend-or-service-for-settings-sync)

The welcome walkthrough relies on a `syncStatus` context key to hide or display the suggestion to sync your data, and unfortunately, without the user data sync services, the context key remains undefined, while the condition is `syncStatus != uninitialized`, so the suggestion is displayed. The only way to hide it is ironically to register the user data sync service override without configuring any server