### PR TITLE
Fixed asset paths in dev on Windows

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -164,6 +164,7 @@
         "ansi-colors": "^4.1.3",
         "dockerode": "^4.0.2",
         "express": "^4.18.2",
+        "import-meta-resolve": "^4.0.0",
         "monaco-editor": "^0.45.0",
         "vscode": "file:../dist/main",
         "ws": "^8.16.0"
@@ -3647,6 +3648,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.0.0.tgz",
+      "integrity": "sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",

--- a/demo/package.json
+++ b/demo/package.json
@@ -65,7 +65,7 @@
     "@codingame/monaco-vscode-gulp-default-extension": "file:../dist/default-extension-gulp",
     "@codingame/monaco-vscode-handlebars-default-extension": "file:../dist/default-extension-handlebars",
     "@codingame/monaco-vscode-hlsl-default-extension": "file:../dist/default-extension-hlsl",
-    "@codingame/monaco-vscode-html-default-extension": "file:../dist/default-extension-html",
+        "@codingame/monaco-vscode-html-default-extension": "file:../dist/default-extension-html",
     "@codingame/monaco-vscode-html-language-features-default-extension": "file:../dist/default-extension-html-language-features",
     "@codingame/monaco-vscode-ini-default-extension": "file:../dist/default-extension-ini",
     "@codingame/monaco-vscode-ipynb-default-extension": "file:../dist/default-extension-ipynb",
@@ -181,6 +181,7 @@
     "ansi-colors": "^4.1.3",
     "dockerode": "^4.0.2",
     "express": "^4.18.2",
+    "import-meta-resolve": "^4.0.0",
     "monaco-editor": "^0.45.0",
     "vscode": "file:../dist/main",
     "ws": "^8.16.0"

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import glob from 'fast-glob'
+import { resolve } from 'import-meta-resolve'
 import * as fs from 'fs'
 import url from 'url'
 import path from 'path'
@@ -33,7 +34,7 @@ export default defineConfig({
         return () => {
           server.middlewares.use(async (req, res, next) => {
             if (req.originalUrl != null) {
-              const pathname = new URL(req.originalUrl, import.meta.url).pathname
+              const pathname = new URL(req.originalUrl, server.resolvedUrls?.local.toString()).pathname
               if (pathname.endsWith('.html')) {
                 res.setHeader('Content-Type', 'text/html')
                 res.writeHead(200)
@@ -79,7 +80,7 @@ export default defineConfig({
               newCode += code.slice(i, match.index)
 
               const path = match[1].slice(1, -1)
-              const resolved = await import.meta.resolve!(path, url.pathToFileURL(args.path))
+              const resolved = await resolve(path, url.pathToFileURL(args.path).toString())
 
               newCode += `new URL(${JSON.stringify(url.fileURLToPath(resolved))}, import.meta.url)`
 


### PR DESCRIPTION
In my environment import.meta.url does not maintain the relative path to the extension in node_modules:
![image](https://github.com/CodinGame/monaco-vscode-api/assets/1424395/1b952a7d-53ac-4955-92d4-0138fa96777b)

So I added NPM package import-meta-resolve and used their resolve method by replacing
```js
const resolved = await import.meta.resolve!(path, url.pathToFileURL(args.path));
```
with
```js
const resolved = await resolve(path, url.pathToFileURL(args.path).toString());
```

But then I had an issue because import.meta.url starts with file://C:/ causing the pathname to be /C:/node_modules which is obviously not correct

![image](https://github.com/CodinGame/monaco-vscode-api/assets/1424395/06de37a9-54d0-49f2-8744-ff30ceab8549)

This can be mitigated by replacing

```js
const pathname = new URL(req.originalUrl, import.meta.url).pathname;
```
with
```js
 const pathname = new URL(req.originalUrl, server.resolvedUrls?.local.toString())
```

