### PR TITLE
Display extensions as builtin

### DIFF
--- a/demo/src/features/debugger.ts
+++ b/demo/src/features/debugger.ts
@@ -1,13 +1,15 @@
 import { ExtensionHostKind, registerExtension } from 'vscode/extensions'
 import type * as vscode from 'vscode'
 
-const { getApi } = registerExtension({
+const { getApi, registerFileUrl } = registerExtension({
   name: 'debugger',
   publisher: 'codingame',
   version: '1.0.0',
   engines: {
     vscode: '*'
   },
+  // A browser field is mandatory for the extension to be flagged as `web`
+  browser: 'extension.js',
   contributes: {
     debuggers: [{
       type: 'javascript',
@@ -19,6 +21,8 @@ const { getApi } = registerExtension({
     }]
   }
 }, ExtensionHostKind.LocalProcess)
+
+registerFileUrl('./extension.js', 'data:text/javascript;base64,' + window.btoa('// nothing'))
 
 const debuggerVscodeApi = await getApi()
 class WebsocketDebugAdapter implements vscode.DebugAdapter {

--- a/src/extension-tools.ts
+++ b/src/extension-tools.ts
@@ -159,6 +159,12 @@ export async function getExtensionResources (manifest: IExtensionManifest, fs: t
 async function extractResourcesFromExtensionManifest (manifest: IExtensionManifest, fs: typeof nodeFs, cwd: string): Promise<string[]> {
   const resources: string[] = []
 
+  const children = await fs.promises.readdir('/')
+  const readme = children.filter(child => /^readme(\.txt|\.md|)$/i.test(child))[0]
+  if (readme != null) resources.push(readme)
+  const changelog = children.filter(child => /^changelog(\.txt|\.md|)$/i.test(child))[0]
+  if (changelog != null) resources.push(changelog)
+
   if (manifest.contributes != null) {
     resources.push(...await extractResourcesFromExtensionManifestContribute(<IExtensionContributions & { [customKey: string]: unknown }>manifest.contributes, fs, cwd))
   }
@@ -176,6 +182,10 @@ async function extractResourcesFromExtensionManifest (manifest: IExtensionManife
       onlyFiles: true
     }))
     resources.push(...bundleFiles)
+  }
+
+  if (manifest.icon != null) {
+    resources.push(manifest.icon)
   }
 
   // remove duplicates

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -29,6 +29,8 @@ export function registerLocalApiFactory (_apiFactory: ApiFactory): void {
 interface RegisterExtensionParams {
   path?: string
   system?: boolean
+  readmePath?: string
+  changelogPath?: string
 }
 
 interface RegisterRemoteExtensionParams extends RegisterExtensionParams {
@@ -95,7 +97,7 @@ export function registerExtension (manifest: IExtensionManifest, extHostKind: Ex
 export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.LocalWebWorker, params?: RegisterExtensionParams): RegisterLocalExtensionResult
 export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.Remote, params?: RegisterRemoteExtensionParams): RegisterRemoteExtensionResult
 export function registerExtension (manifest: IExtensionManifest, extHostKind?: ExtensionHostKind, params?: RegisterExtensionParams): RegisterExtensionResult
-export function registerExtension (manifest: IExtensionManifest, extHostKind?: ExtensionHostKind, { path = '/', system = false }: RegisterExtensionParams = {}): RegisterExtensionResult {
+export function registerExtension (manifest: IExtensionManifest, extHostKind?: ExtensionHostKind, { path = '/', system = false, readmePath, changelogPath }: RegisterExtensionParams = {}): RegisterExtensionResult {
   const id = getExtensionId(manifest.publisher, manifest.name)
   const location = URI.from({ scheme: CustomSchemas.extensionFile, authority: id, path })
 
@@ -120,7 +122,9 @@ export function registerExtension (manifest: IExtensionManifest, extHostKind?: E
       targetPlatform: TargetPlatform.WEB,
       isValid: true,
       validations: [],
-      extHostKind
+      extHostKind,
+      readmeUrl: readmePath != null ? URI.joinPath(realLocation, readmePath) : undefined,
+      changelogUrl: changelogPath != null ? URI.joinPath(realLocation, changelogPath) : undefined
     }
 
     await deltaExtensions({ toAdd: [extension], toRemove: [] })

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -27,8 +27,8 @@ export function registerLocalApiFactory (_apiFactory: ApiFactory): void {
 }
 
 interface RegisterExtensionParams {
-  builtin?: boolean
   path?: string
+  system?: boolean
 }
 
 interface RegisterRemoteExtensionParams extends RegisterExtensionParams {
@@ -95,7 +95,7 @@ export function registerExtension (manifest: IExtensionManifest, extHostKind: Ex
 export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.LocalWebWorker, params?: RegisterExtensionParams): RegisterLocalExtensionResult
 export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.Remote, params?: RegisterRemoteExtensionParams): RegisterRemoteExtensionResult
 export function registerExtension (manifest: IExtensionManifest, extHostKind?: ExtensionHostKind, params?: RegisterExtensionParams): RegisterExtensionResult
-export function registerExtension (manifest: IExtensionManifest, extHostKind?: ExtensionHostKind, { builtin = manifest.publisher === 'vscode', path = '/' }: RegisterExtensionParams = {}): RegisterExtensionResult {
+export function registerExtension (manifest: IExtensionManifest, extHostKind?: ExtensionHostKind, { path = '/', system = false }: RegisterExtensionParams = {}): RegisterExtensionResult {
   const disposableStore = new DisposableStore()
   const id = getExtensionId(manifest.publisher, manifest.name)
   const location = URI.from({ scheme: CustomSchemas.extensionFile, authority: id, path })
@@ -114,8 +114,8 @@ export function registerExtension (manifest: IExtensionManifest, extHostKind?: E
 
     const extension: IExtensionWithExtHostKind = {
       manifest: localizedManifest,
-      type: builtin ? ExtensionType.System : ExtensionType.User,
-      isBuiltin: builtin,
+      type: system ? ExtensionType.System : ExtensionType.User,
+      isBuiltin: true,
       identifier: { id },
       location: realLocation,
       targetPlatform: TargetPlatform.WEB,

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -93,6 +93,11 @@ export async function registerRemoteExtension (directory: string): Promise<Regis
   return registerExtension(manifest, ExtensionHostKind.Remote, { path: directory })
 }
 
+const extensions: IExtension[] = []
+export function getExtensionManifests (): IExtension[] {
+  return extensions
+}
+
 export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.LocalProcess, params?: RegisterExtensionParams): RegisterLocalProcessExtensionResult
 export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.LocalWebWorker, params?: RegisterExtensionParams): RegisterLocalExtensionResult
 export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.Remote, params?: RegisterRemoteExtensionParams): RegisterRemoteExtensionResult
@@ -127,6 +132,10 @@ export function registerExtension (manifest: IExtensionManifest, extHostKind?: E
       changelogUrl: changelogPath != null ? URI.joinPath(realLocation, changelogPath) : undefined
     }
 
+    if (extHostKind !== ExtensionHostKind.Remote) {
+      extensions.push(extension)
+    }
+
     await deltaExtensions({ toAdd: [extension], toRemove: [] })
 
     return extension
@@ -139,6 +148,12 @@ export function registerExtension (manifest: IExtensionManifest, extHostKind?: E
     },
     async dispose () {
       const extension = await addExtensionPromise
+
+      const index = extensions.indexOf(extension)
+      if (index >= 0) {
+        extensions.splice(extensions.indexOf(extension), 1)
+      }
+
       await deltaExtensions({ toAdd: [], toRemove: [extension] })
     }
   }

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -96,7 +96,6 @@ export function registerExtension (manifest: IExtensionManifest, extHostKind: Ex
 export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.Remote, params?: RegisterRemoteExtensionParams): RegisterRemoteExtensionResult
 export function registerExtension (manifest: IExtensionManifest, extHostKind?: ExtensionHostKind, params?: RegisterExtensionParams): RegisterExtensionResult
 export function registerExtension (manifest: IExtensionManifest, extHostKind?: ExtensionHostKind, { path = '/', system = false }: RegisterExtensionParams = {}): RegisterExtensionResult {
-  const disposableStore = new DisposableStore()
   const id = getExtensionId(manifest.publisher, manifest.name)
   const location = URI.from({ scheme: CustomSchemas.extensionFile, authority: id, path })
 
@@ -137,7 +136,6 @@ export function registerExtension (manifest: IExtensionManifest, extHostKind?: E
     async dispose () {
       const extension = await addExtensionPromise
       await deltaExtensions({ toAdd: [], toRemove: [extension] })
-      disposableStore.dispose()
     }
   }
 

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -95,9 +95,13 @@ export async function registerRemoteExtension (directory: string): Promise<Regis
   return registerExtension(manifest, ExtensionHostKind.Remote, { path: directory })
 }
 
+const forcedExtensionHostKinds = new Map<string, ExtensionHostKind>()
 const extensions: IExtension[] = []
 export function getExtensionManifests (): IExtension[] {
   return extensions
+}
+export function getForcedExtensionHostKind (id: string): ExtensionHostKind | undefined {
+  return forcedExtensionHostKinds.get(id)
 }
 
 export function registerExtension (manifest: IExtensionManifest, extHostKind: ExtensionHostKind.LocalProcess, params?: RegisterExtensionParams): RegisterLocalProcessExtensionResult
@@ -134,6 +138,9 @@ export function registerExtension (manifest: IExtensionManifest, extHostKind?: E
       changelogUrl: changelogPath != null ? URI.joinPath(realLocation, changelogPath) : undefined
     }
 
+    if (extHostKind != null) {
+      forcedExtensionHostKinds.set(id, extHostKind)
+    }
     if (extHostKind !== ExtensionHostKind.Remote) {
       extensions.push(extension)
     }
@@ -164,6 +171,7 @@ export function registerExtension (manifest: IExtensionManifest, extHostKind?: E
       if (index >= 0) {
         extensions.splice(extensions.indexOf(extension), 1)
       }
+      forcedExtensionHostKinds.delete(id)
 
       await deltaExtensions({ toAdd: [], toRemove: [extension] })
     }

--- a/src/localExtensionHost.ts
+++ b/src/localExtensionHost.ts
@@ -49,21 +49,23 @@ class LocalExtHostExtensionService extends ExtHostExtensionService {
     ])
     const extensionRegistry = { mine: myRegistry, all: this._globalRegistry }
 
-    const ext = extensionId != null ? myRegistry.getExtensionDescription(extensionId) : undefined
-    if (ext != null) {
-      let apiImpl = this._extApiImpl.get(ext.identifier)
-      if (apiImpl == null) {
-        apiImpl = this._apiFactory!(ext, extensionRegistry, configProvider)
-        this._extApiImpl.set(ext.identifier, apiImpl)
+    if (extensionId == null) {
+      if (this._defaultApiImpl == null) {
+        this._defaultApiImpl = this._apiFactory!(nullExtensionDescription, extensionRegistry, configProvider)
       }
-      return apiImpl
+      return this._defaultApiImpl
     }
 
-    // fall back to a default implementation
-    if (this._defaultApiImpl == null) {
-      this._defaultApiImpl = this._apiFactory!(nullExtensionDescription, extensionRegistry, configProvider)
+    const ext = myRegistry.getExtensionDescription(extensionId)
+    if (ext == null) {
+      throw new Error(`Extension ${extensionId} does not exist or is disabled`)
     }
-    return this._defaultApiImpl
+    let apiImpl = this._extApiImpl.get(ext.identifier)
+    if (apiImpl == null) {
+      apiImpl = this._apiFactory!(ext, extensionRegistry, configProvider)
+      this._extApiImpl.set(ext.identifier, apiImpl)
+    }
+    return apiImpl
   }
 }
 

--- a/src/rollup-extension-directory-plugin.ts
+++ b/src/rollup-extension-directory-plugin.ts
@@ -55,6 +55,10 @@ export default function plugin ({
         try {
           const resources = await getExtensionResources(manifest, fs, id)
 
+          const resourcePaths = resources.map(r => r.path)
+          const readmePath = resourcePaths.filter(child => /^readme(\.txt|\.md|)$/i.test(child))[0]
+          const changelogPath = resourcePaths.filter(child => /^changelog(\.txt|\.md|)$/i.test(child))[0]
+
           function generateFileRegistrationInstruction (filePath: string, importPath: string, mimeType?: string) {
             return `registerFileUrl('${filePath}', new URL('${importPath}', import.meta.url).toString()${mimeType != null ? `, '${mimeType}'` : ''})`
           }
@@ -63,7 +67,7 @@ export default function plugin ({
 import manifest from '${manifestPath}'
 import { registerExtension } from 'vscode/extensions'
 
-const { registerFileUrl, whenReady } = registerExtension(manifest)
+const { registerFileUrl, whenReady } = registerExtension(manifest, undefined, ${JSON.stringify({ system: true, readmePath, changelogPath })})
 ${resources.map(resource => {
   const lines: string[] = resource.extensionPaths.map(extensionPath =>
     generateFileRegistrationInstruction(extensionPath, path.resolve(id, resource.path), resource.mimeType)

--- a/src/rollup-vsix-plugin.ts
+++ b/src/rollup-vsix-plugin.ts
@@ -83,6 +83,10 @@ export default function plugin ({
 
       const resources = await getExtensionResources(manifest, <typeof nodeFs><unknown>vsixFS, '/')
 
+      const resourcePaths = resources.map(r => r.path)
+      const readmePath = resourcePaths.filter(child => /^readme(\.txt|\.md|)$/i.test(child))[0]
+      const changelogPath = resourcePaths.filter(child => /^changelog(\.txt|\.md|)$/i.test(child))[0]
+
       const pathMapping = (await Promise.all(resources.map(async resource => {
         const assetPath = getVsixPath(resource.path)
         let url: string
@@ -109,7 +113,7 @@ import { registerExtension } from 'vscode/extensions'
 
 const manifest = ${JSON.stringify(manifest)}
 
-const { registerFileUrl, whenReady } = registerExtension(manifest)
+const { registerFileUrl, whenReady } = registerExtension(manifest, undefined, ${JSON.stringify({ system: true, readmePath, changelogPath })})
 
 ${pathMapping.map(({ pathInExtension, url, mimeType }) => (`
 registerFileUrl('${pathInExtension}', ${url}${mimeType != null ? `, '${mimeType}'` : ''})`)).join('\n')}

--- a/src/service-override/extensionGallery.ts
+++ b/src/service-override/extensionGallery.ts
@@ -32,7 +32,9 @@ import { getExtensionManifests } from '../extensions'
 
 // plugin-import-meta-asset only allows relative paths
 registerAssets({
-  'vs/workbench/services/extensionManagement/common/media/defaultIcon.png': new URL('../../vscode/src/vs/workbench/services/extensionManagement/common/media/defaultIcon.png', import.meta.url).toString()
+  'vs/workbench/services/extensionManagement/common/media/defaultIcon.png': new URL('../../vscode/src/vs/workbench/services/extensionManagement/common/media/defaultIcon.png', import.meta.url).toString(),
+  'vs/workbench/contrib/extensions/browser/media/theme-icon.png': new URL('../../vscode/src/vs/workbench/contrib/extensions/browser/media/theme-icon.png', import.meta.url).href,
+  'vs/workbench/contrib/extensions/browser/media/language-icon.svg': new URL('../../vscode/src/vs/workbench/contrib/extensions/browser/media/theme-icon.png', import.meta.url).href
 })
 
 class ExtensionManagementServerServiceOverride extends ExtensionManagementServerService {

--- a/src/service-override/extensionGallery.ts
+++ b/src/service-override/extensionGallery.ts
@@ -13,8 +13,7 @@ import { WebExtensionsScannerService } from 'vs/workbench/services/extensionMana
 import { IExtensionRecommendationNotificationService } from 'vs/platform/extensionRecommendations/common/extensionRecommendations'
 import { IIgnoredExtensionsManagementService, IgnoredExtensionsManagementService } from 'vs/platform/userDataSync/common/ignoredExtensions'
 import { ExtensionManifestPropertiesService, IExtensionManifestPropertiesService } from 'vs/workbench/services/extensions/common/extensionManifestPropertiesService'
-import { IBuiltinExtensionsScannerService } from 'vs/platform/extensions/common/extensions'
-import { BuiltinExtensionsScannerService } from 'vs/workbench/services/extensionManagement/browser/builtinExtensionsScannerService'
+import { IBuiltinExtensionsScannerService, IExtension } from 'vs/platform/extensions/common/extensions'
 import { ExtensionIgnoredRecommendationsService } from 'vs/workbench/services/extensionRecommendations/common/extensionIgnoredRecommendationsService'
 import { IWorkspaceExtensionsConfigService, WorkspaceExtensionsConfigService } from 'vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig'
 import { ExtensionRecommendationNotificationService } from 'vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService'
@@ -29,6 +28,7 @@ import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteA
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation'
 import { ILabelService } from 'vs/platform/label/common/label'
 import { registerAssets } from '../assets'
+import { getExtensionManifests } from '../extensions'
 
 // plugin-import-meta-asset only allows relative paths
 registerAssets({
@@ -57,6 +57,14 @@ class ExtensionManagementServerServiceOverride extends ExtensionManagementServer
   }
 }
 
+class CustomBuiltinExtensionsScannerService implements IBuiltinExtensionsScannerService {
+  _serviceBrand: undefined
+
+  async scanBuiltinExtensions (): Promise<IExtension[]> {
+    return getExtensionManifests()
+  }
+}
+
 export interface ExtensionGalleryOptions {
   /**
    * Whether we should only allow for web extensions to be installed, this is generally
@@ -78,7 +86,7 @@ export default function getServiceOverride (options: ExtensionGalleryOptions = {
     [IIgnoredExtensionsManagementService.toString()]: new SyncDescriptor(IgnoredExtensionsManagementService, [], true),
     [IExtensionManifestPropertiesService.toString()]: new SyncDescriptor(ExtensionManifestPropertiesService, [], true),
     [IExtensionManagementService.toString()]: new SyncDescriptor(ExtensionManagementService, [], true),
-    [IBuiltinExtensionsScannerService.toString()]: new SyncDescriptor(BuiltinExtensionsScannerService, [], true),
+    [IBuiltinExtensionsScannerService.toString()]: new SyncDescriptor(CustomBuiltinExtensionsScannerService, [], true),
     [IWorkspaceExtensionsConfigService.toString()]: new SyncDescriptor(WorkspaceExtensionsConfigService, [], true),
     [IExtensionTipsService.toString()]: new SyncDescriptor(ExtensionTipsService, [], true),
     [IRemoteUserDataProfilesService.toString()]: new SyncDescriptor(RemoteUserDataProfilesService, [], true),


### PR DESCRIPTION
Display extensions registered with `registerExtension` as builtin in the extension panel:

![image](https://github.com/CodinGame/monaco-vscode-api/assets/23257479/e8be3194-922f-4dec-80dc-c2d47f42ed4e)