### PR TITLE
Restore standalone editor style

### DIFF
--- a/scripts/vscode.patch
+++ b/scripts/vscode.patch
@@ -481,18 +481,62 @@ index 7f675f67e9d..9c20173bd7a 100644
  
  					if (selections.length) {
  						this._state.change({ searchScope: selections as Range[] }, true);
-diff --git a/src/vs/editor/standalone/browser/standaloneEditor.ts b/src/vs/editor/standalone/browser/standaloneEditor.ts
-index 059a4928862..8e31d662d19 100644
---- a/src/vs/editor/standalone/browser/standaloneEditor.ts
-+++ b/src/vs/editor/standalone/browser/standaloneEditor.ts
-@@ -7,7 +7,6 @@ import { mainWindow } from 'vs/base/browser/window';
- import { Disposable, DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
- import { splitLines } from 'vs/base/common/strings';
- import { URI } from 'vs/base/common/uri';
--import 'vs/css!./standalone-tokens';
- import { FontMeasurements } from 'vs/editor/browser/config/fontMeasurements';
- import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
- import { EditorCommand, ServicesAccessor } from 'vs/editor/browser/editorExtensions';
+diff --git a/src/vs/editor/standalone/browser/standalone-tokens.css b/src/vs/editor/standalone/browser/standalone-tokens.css
+index 1fc85078f9e..177900f75c5 100644
+--- a/src/vs/editor/standalone/browser/standalone-tokens.css
++++ b/src/vs/editor/standalone/browser/standalone-tokens.css
+@@ -5,7 +5,7 @@
+ 
+ 
+ /* Default standalone editor fonts */
+-.monaco-editor {
++.standalone-monaco-editor {
+ 	font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", system-ui, "Ubuntu", "Droid Sans", sans-serif;
+ 	--monaco-monospace-font: "SF Mono", Monaco, Menlo, Consolas, "Ubuntu Mono", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
+ }
+@@ -37,16 +37,16 @@
+ 	clip-path: inset(50%);
+ }
+ 
+-.monaco-editor, .monaco-diff-editor .synthetic-focus,
+-.monaco-editor, .monaco-diff-editor [tabindex="0"]:focus,
+-.monaco-editor, .monaco-diff-editor [tabindex="-1"]:focus,
+-.monaco-editor, .monaco-diff-editor button:focus,
+-.monaco-editor, .monaco-diff-editor input[type=button]:focus,
+-.monaco-editor, .monaco-diff-editor input[type=checkbox]:focus,
+-.monaco-editor, .monaco-diff-editor input[type=search]:focus,
+-.monaco-editor, .monaco-diff-editor input[type=text]:focus,
+-.monaco-editor, .monaco-diff-editor select:focus,
+-.monaco-editor, .monaco-diff-editor textarea:focus {
++.standalone-monaco-editor, .monaco-diff-editor .synthetic-focus,
++.standalone-monaco-editor, .monaco-diff-editor [tabindex="0"]:focus,
++.standalone-monaco-editor, .monaco-diff-editor [tabindex="-1"]:focus,
++.standalone-monaco-editor, .monaco-diff-editor button:focus,
++.standalone-monaco-editor, .monaco-diff-editor input[type=button]:focus,
++.standalone-monaco-editor, .monaco-diff-editor input[type=checkbox]:focus,
++.standalone-monaco-editor, .monaco-diff-editor input[type=search]:focus,
++.standalone-monaco-editor, .monaco-diff-editor input[type=text]:focus,
++.standalone-monaco-editor, .monaco-diff-editor select:focus,
++.standalone-monaco-editor, .monaco-diff-editor textarea:focus {
+ 	outline-width: 1px;
+ 	outline-style: solid;
+ 	outline-offset: -1px;
+diff --git a/src/vs/editor/standalone/browser/standaloneCodeEditor.ts b/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
+index 60c16599bf3..15bae7fc867 100644
+--- a/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
++++ b/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
+@@ -421,7 +421,10 @@ export class StandaloneEditor extends StandaloneCodeEditor implements IStandalon
+ 		@ILanguageConfigurationService languageConfigurationService: ILanguageConfigurationService,
+ 		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
+ 	) {
+-		const options = { ..._options };
++		const options = {
++			extraEditorClassName: 'standalone-monaco-editor',
++			..._options
++		};
+ 		updateConfigurationService(configurationService, options, false);
+ 		const themeDomRegistration = (<StandaloneThemeService>themeService).registerEditorContainer(domElement);
+ 		if (typeof options.theme === 'string') {
 diff --git a/src/vs/editor/standalone/browser/standaloneServices.ts b/src/vs/editor/standalone/browser/standaloneServices.ts
 index 97841a6012b..f7f7a5a021a 100644
 --- a/src/vs/editor/standalone/browser/standaloneServices.ts


### PR DESCRIPTION
But apply it only on standalone editors

@kaisalmen it's a fix for https://github.com/TypeFox/monaco-languageclient/pull/600#issuecomment-1964017110

Removing it doesn't seem to be an issue on Linux but it is on Window