### PR TITLE
Vscode 1.87.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,22 +37,21 @@ jobs:
       run: npm ci
     - name: Build demo
       working-directory: ./demo
-      run: npm run build:github
-    - name: Setup Pages
-      uses: actions/configure-pages@v4
-    - name: Upload demo artifact
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: ./demo/dist/
-        retention-days: 7
+      run: npm run build:netlify
   deploy:
-    if: success() && github.ref == 'refs/heads/main'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    if: success()
     runs-on: ubuntu-latest
     needs: release
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v3.0
+        with:
+          publish-dir: './demo/dist'
+          production-branch: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: ${{ github.event.pull_request.title }}
+          netlify-config-path: ./demo/netlify.toml
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ This library also offers the possibility to localize vscode and the extensions i
 
 ### Demo
 
-Try it out on https://codingame.github.io/monaco-vscode-api/
+Try it out on https://monaco-vscode-api.netlify.app/
 
 There is a demo that showcases the service-override features. It allows to register contributions with the same syntaxes as in VSCode.
 It includes:

--- a/demo/netlify.toml
+++ b/demo/netlify.toml
@@ -1,0 +1,5 @@
+[[headers]]
+for = "/*"
+  [headers.values]
+    Cross-Origin-Opener-Policy = "same-origin"
+    Cross-Origin-Embedder-Policy = "credentialless"

--- a/demo/package.json
+++ b/demo/package.json
@@ -9,7 +9,7 @@
     "start": "NODE_OPTIONS=--experimental-import-meta-resolve vite --config vite.config.ts",
     "start:debug": "vite --config vite.config.ts --debug --force",
     "build": "vite --config vite.config.ts build",
-    "build:github": "tsc --noEmit && vite --config vite.github-page.config.ts build && touch dist/.nojekyll",
+    "build:netlify": "tsc --noEmit && vite --config vite.netlify.config.ts build",
     "start:debugServer": "node --loader ts-node/esm src/debugServer.ts",
     "start:extHostServer": "WEB_ENDPOINT_URL_TEMPLATE=http://localhost:5173/ vscode-ext-host-server --without-connection-token"
   },

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -24,5 +24,5 @@
       "./node_modules/@types"
     ]
   },
-  "include": ["src", "vite.config.ts", "vite.github-page.config.ts"]
+  "include": ["src", "vite.config.ts", "vite.netlify.config.ts"]
 }

--- a/demo/vite.netlify.config.ts
+++ b/demo/vite.netlify.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
   worker: {
     format: 'es'
   },
-  base: 'https://codingame.github.io/monaco-vscode-api',
   resolve: {
     dedupe: ['vscode', ...localDependencies]
   }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "config": {
     "vscode": {
-      "version": "1.87.1",
-      "ref": "1.87.1"
+      "version": "1.87.2",
+      "ref": "1.87.2"
     }
   },
   "devDependencies": {

--- a/src/service-override/files.ts
+++ b/src/service-override/files.ts
@@ -43,6 +43,10 @@ abstract class RegisteredFile {
     this.ctime = Date.now()
     this.mtime = Date.now()
     this.type = FileType.File
+
+    this.onDidChange(() => {
+      this.mtime = Date.now()
+    })
   }
 
   async stats (): Promise<IStat> {

--- a/vscode-paches/0060-feat-hide-terminal-view-if-there-is-no-backend-avail.patch
+++ b/vscode-paches/0060-feat-hide-terminal-view-if-there-is-no-backend-avail.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lo=C3=AFc=20Mangeonjean?= <loic@coderpad.io>
+Date: Wed, 13 Mar 2024 19:31:38 +0100
+Subject: [PATCH] feat: hide terminal view if there is no backend available
+
+---
+ .../workbench/contrib/terminal/browser/terminal.contribution.ts  | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts b/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+index fba9c78e785..336d89cfcca 100644
+--- a/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
++++ b/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+@@ -138,6 +138,7 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
+ 	canToggleVisibility: false,
+ 	canMoveView: true,
+ 	ctorDescriptor: new SyncDescriptor(TerminalViewPane),
++	when: TerminalContextKeys.processSupported,
+ 	openCommandActionDescriptor: {
+ 		id: TerminalCommandId.Toggle,
+ 		mnemonicTitle: nls.localize({ key: 'miToggleIntegratedTerminal', comment: ['&& denotes a mnemonic'] }, "&&Terminal"),
+-- 
+2.34.1
+


### PR DESCRIPTION
switch to netlify to be able to set headers allowing the typescript worker to use shared array buffer and enable project wide intellisense