### PR TITLE
feat: add secret storage service

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ Additionally, several packages that include the VSCode version of some services 
   - Update detection, release notes...
 - **Localization**
   - Register callbacks to update the display language from the VSCode UI (either from the `Set Display Language` command or from the extension gallery extension packs)
+- **Secret Storage**
+  - Storage of secrets for extensions, will store by default in-memory. You can pass a custom implementation as part of the workbench construction options when initializing monaco services (under `secretStorageProvider`).
 
 Usage:
 

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -120,6 +120,7 @@
         "@codingame/monaco-vscode-scss-default-extension": "file:../dist/default-extension-scss",
         "@codingame/monaco-vscode-search-result-default-extension": "file:../dist/default-extension-search-result",
         "@codingame/monaco-vscode-search-service-override": "file:../dist/service-override-search",
+        "@codingame/monaco-vscode-secret-storage-service-override": "file:../dist/service-override-secret-storage",
         "@codingame/monaco-vscode-shaderlab-default-extension": "file:../dist/default-extension-shaderlab",
         "@codingame/monaco-vscode-share-service-override": "file:../dist/service-override-share",
         "@codingame/monaco-vscode-shellscript-default-extension": "file:../dist/default-extension-shellscript",
@@ -1211,6 +1212,13 @@
         "vscode": "npm:@codingame/monaco-vscode-api@^0.0.0-semantic-release"
       }
     },
+    "../dist/service-override-secret-storage": {
+      "version": "0.0.0-semantic-release",
+      "license": "MIT",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@^0.0.0-semantic-release"
+      }
+    },
     "../dist/service-override-share": {
       "name": "@codingame/monaco-vscode-share-service-override",
       "version": "0.0.0-semantic-release",
@@ -1997,6 +2005,10 @@
     },
     "node_modules/@codingame/monaco-vscode-search-service-override": {
       "resolved": "../dist/service-override-search",
+      "link": true
+    },
+    "node_modules/@codingame/monaco-vscode-secret-storage-service-override": {
+      "resolved": "../dist/service-override-secret-storage",
       "link": true
     },
     "node_modules/@codingame/monaco-vscode-shaderlab-default-extension": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -139,6 +139,7 @@
     "@codingame/monaco-vscode-scss-default-extension": "file:../dist/default-extension-scss",
     "@codingame/monaco-vscode-search-result-default-extension": "file:../dist/default-extension-search-result",
     "@codingame/monaco-vscode-search-service-override": "file:../dist/service-override-search",
+    "@codingame/monaco-vscode-secret-storage-service-override": "file:../dist/service-override-secret-storage",
     "@codingame/monaco-vscode-shaderlab-default-extension": "file:../dist/default-extension-shaderlab",
     "@codingame/monaco-vscode-share-service-override": "file:../dist/service-override-share",
     "@codingame/monaco-vscode-shellscript-default-extension": "file:../dist/default-extension-shellscript",

--- a/demo/src/setup.common.ts
+++ b/demo/src/setup.common.ts
@@ -10,6 +10,7 @@ import getDialogsServiceOverride from '@codingame/monaco-vscode-dialogs-service-
 import getTextmateServiceOverride from '@codingame/monaco-vscode-textmate-service-override'
 import getThemeServiceOverride from '@codingame/monaco-vscode-theme-service-override'
 import getLanguagesServiceOverride from '@codingame/monaco-vscode-languages-service-override'
+import getSecretStorageServiceOverride from '@codingame/monaco-vscode-secret-storage-service-override'
 import getAuthenticationServiceOverride from '@codingame/monaco-vscode-authentication-service-override'
 import getScmServiceOverride from '@codingame/monaco-vscode-scm-service-override'
 import getExtensionGalleryServiceOverride from '@codingame/monaco-vscode-extension-gallery-service-override'
@@ -386,5 +387,6 @@ export const commonServices: IEditorOverrideServices = {
       locale: 'en',
       languageName: 'English'
     }]
-  })
+  }),
+  ...getSecretStorageServiceOverride()
 }

--- a/scripts/install-vscode
+++ b/scripts/install-vscode
@@ -79,7 +79,10 @@ cd src
 
 # Remove useless files
 rm -rf `find . -name '*.test.ts' -o -name 'test' -o -name 'electron-browser'`
-rm -rf vs/code
+rm -rf vs/code/electron-main
+rm -rf vs/code/electron-sandbox
+rm -rf vs/code/node
+rm -rf vs/code/test
 
 mkdir -p $output_directory
 echo $vscodeRef > $version_info

--- a/src/service-override/secretStorage.ts
+++ b/src/service-override/secretStorage.ts
@@ -1,0 +1,15 @@
+import { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
+import { IEncryptionService } from 'vs/platform/encryption/common/encryptionService'
+import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
+import { ISecretStorageService } from 'vs/platform/secrets/common/secrets'
+import { EncryptionService } from 'vs/workbench/services/encryption/browser/encryptionService'
+import { BrowserSecretStorageService } from 'vs/workbench/services/secrets/browser/secretStorageService'
+
+export { LocalStorageSecretStorageProvider } from 'vs/code/browser/workbench/workbench'
+
+export default function getServiceOverride (): IEditorOverrideServices {
+  return {
+    [ISecretStorageService.toString()]: new SyncDescriptor(BrowserSecretStorageService, [], true),
+    [IEncryptionService.toString()]: new SyncDescriptor(EncryptionService, [], true)
+  }
+}


### PR DESCRIPTION
This adds the `ISecretStorage` service override. In the browser this is just plain storage in memory. This service is needed by some extensions (like the Thunder Client) extension.

An implementation can actually be passed when initializing VSCode, if that's not available it will default to storing the secrets in-memory.