### PR TITLE
fix: add missing accessibleView service

### DIFF
--- a/src/missing-services.ts
+++ b/src/missing-services.ts
@@ -222,6 +222,7 @@ import { AccountStatus } from 'vs/workbench/services/userDataSync/common/userDat
 import { IWebview } from 'vs/workbench/contrib/webview/browser/webview'
 import { SyncResource } from 'vs/workbench/contrib/editSessions/common/editSessions'
 import { ILanguageModelStatsService } from 'vs/workbench/contrib/chat/common/languageModelStats.service'
+import { IAccessibleViewInformationService } from 'vs/workbench/services/accessibility/common/accessibleViewInformationService.service'
 import { getBuiltInExtensionTranslationsUris, getExtensionIdProvidingCurrentLocale } from './l10n'
 import { unsupported } from './tools'
 
@@ -2288,6 +2289,11 @@ registerSingleton(IAccessibleViewService, class AccessibleViewService implements
   getPosition = unsupported
   setPosition = unsupported
   getLastPosition = unsupported
+}, InstantiationType.Delayed)
+
+registerSingleton(IAccessibleViewInformationService, class AccessibleViewInformationService implements IAccessibleViewInformationService {
+  _serviceBrand: undefined
+  hasShownAccessibleView = () => false
 }, InstantiationType.Delayed)
 
 registerSingleton(IWorkbenchExtensionManagementService, class WorkbenchExtensionManagementService implements IWorkbenchExtensionManagementService {

--- a/src/service-override/accessibility.ts
+++ b/src/service-override/accessibility.ts
@@ -5,6 +5,10 @@ import { AccessibilitySignalService } from 'vs/platform/accessibilitySignal/brow
 import audioAssets from 'vs/platform/accessibilitySignal/browser/media/*.mp3'
 import { IAccessibleViewService } from 'vs/workbench/contrib/accessibility/browser/accessibleView.service'
 import { IAccessibilitySignalService } from 'vs/platform/accessibilitySignal/browser/accessibilitySignalService.service'
+import { IAccessibleViewInformationService } from 'vs/workbench/services/accessibility/common/accessibleViewInformationService.service'
+import { AccessibleViewInformationService } from 'vs/workbench/services/accessibility/common/accessibleViewInformationService'
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility.service'
+import { AccessibilityService } from 'vs/platform/accessibility/browser/accessibilityService'
 import { registerAssets } from '../assets'
 import 'vs/workbench/contrib/accessibility/browser/accessibility.contribution'
 import 'vs/workbench/contrib/codeEditor/browser/accessibility/accessibility'
@@ -15,6 +19,8 @@ registerAssets(audioAssets)
 export default function getServiceOverride (): IEditorOverrideServices {
   return {
     [IAccessibleViewService.toString()]: new SyncDescriptor(AccessibleViewService, [], true),
-    [IAccessibilitySignalService.toString()]: new SyncDescriptor(AccessibilitySignalService, [], true)
+    [IAccessibilitySignalService.toString()]: new SyncDescriptor(AccessibilitySignalService, [], true),
+    [IAccessibilityService.toString()]: new SyncDescriptor(AccessibilityService, [], true),
+    [IAccessibleViewInformationService.toString()]: new SyncDescriptor(AccessibleViewInformationService, [], true)
   }
 }


### PR DESCRIPTION
I noticed that sometimes a new service (introduced with VSCode 1.89) is required, called the `AccessibleViewInformationService`. In this PR I add this service, together with another service related to accessibility I found.

Fixes: 

<img width="950" alt="image" src="https://github.com/CodinGame/monaco-vscode-api/assets/587016/9a77df9e-50a1-4a47-8670-a053b549ff90">
