### PR TITLE
Full containerized build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:noble-20240605
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,15 @@
-FROM node:18-bullseye
+FROM ubuntu
 
-RUN apt update -y && apt install -y jq rsync libsecret-1-dev
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update \
+    && apt upgrade -y \
+    && apt install -y curl git python3 python-is-python3 build-essential jq rsync libkrb5-dev libsecret-1-dev
+
+RUN curl https://get.volta.sh | bash
+ENV VOLTA_FEATURE_PNPM=1
+ENV VOLTA_HOME "/root/.volta"
+ENV PATH "$VOLTA_HOME/bin:$PATH"
+
+RUN volta install node@20 \
+    && volta install yarn@1
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
-  "name": "monaco-vscode-api",
-  "build": {
-    "context": ".",
-    "dockerfile": "./Dockerfile"
-  }
+	"name": "mva-docker",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "./Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "ubuntu",
+
+	// "mounts": [
+	// 	{
+	// 		"source": "${localWorkspaceFolder}",
+	// 		"target": "/home/ubuntu/monaco-vscode-api",
+	// 		"type": "bind"
+	// 	}
+	// ],
+
+	// "workspaceFolder": "/home/ubuntu/monaco-vscode-api"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  monaco-vscode-api-dev:
+    build:
+      dockerfile: ./.devcontainer/Dockerfile
+      context: ..
+    image: monaco-vscode-api-dev
+    container_name: monaco-vscode-api-dev
+    volumes:
+      - ./:/home/ubuntu/monaco-vscode-api

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly


### PR DESCRIPTION
Allow to build project in container and to use vscode devcontainer for development.

@CGNonofr this is to overcome build problems on Windows. The Dockerfile also basically describes what needs to be installed on a Linux system to allow building the project.

This should circumvent https://github.com/CodinGame/monaco-vscode-api/issues/420 and I will not document https://github.com/CodinGame/monaco-vscode-api/issues/420#issuecomment-2092405137 in the Troubleshooting because it is Windows tooling /node-gyp issue independent of this project,

TODO:
- [x] Install, build and demo build must work in container
- [x] Update REAMDE / Troubleshooting section