### PR TITLE
Fix worker configuration, for real

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git@github.com:CodinGame/monaco-vscode-api.git"
+    "url": "git+ssh://git@github.com/CodinGame/monaco-vscode-api.git"
   },
   "type": "module",
   "scripts": {

--- a/src/workers/editor.worker.ts
+++ b/src/workers/editor.worker.ts
@@ -1,1 +1,1 @@
-export * from 'vs/editor/common/services/editorSimpleWorker.esm.js'
+export * from 'vs/editor/editor.worker'


### PR DESCRIPTION
I tried to homogenize the imports but it was a mistake...

`editorSimpleWorker.esm.js` doesn't reexport the `initialize` function