### PR TITLE
fix: bunle everything if the extension has a "main" entry point

### DIFF
--- a/src/extension-tools.ts
+++ b/src/extension-tools.ts
@@ -220,7 +220,7 @@ export async function getExtensionResources(
   fs: typeof nodeFs,
   cwd: string
 ): Promise<ExtensionResource[]> {
-  if (manifest.browser != null || manifest.contributes?.typescriptServerPlugins != null) {
+  if (manifest.main != null || manifest.browser != null || manifest.contributes?.typescriptServerPlugins != null) {
     // there is some js in the extension, it's impossible to predict which file will be used, bundle everything
     return (
       await glob('**/*', {


### PR DESCRIPTION
VScode extensions with `main` entry point contain some js, as well as `browser`.

I tried bundling [vscode-rbs-syntax vsix](https://github.com/soutaro/vscode-rbs-syntax) but `rollup-vsix-plugin` did not include its `out/extension.js`. If I specify a dummy `browser` entry point to the vsix, it worked. So I think this change is needed.