### PR TITLE
Wrong type dedup

### DIFF
--- a/rollup/tools/typeDedup.ts
+++ b/rollup/tools/typeDedup.ts
@@ -22,7 +22,12 @@ function replaceInterface(int: ts.InterfaceDeclaration, from: string, entityName
     false
   )
 
-  return ts.factory.createTypeAliasDeclaration(undefined, int.name, int.typeParameters, importType)
+  return ts.factory.createTypeAliasDeclaration(
+    int.modifiers,
+    int.name,
+    int.typeParameters,
+    importType
+  )
 }
 function createReplacer(from: string, names: string[]): (int: ts.InterfaceDeclaration) => ts.Node {
   return (int: ts.InterfaceDeclaration) => replaceInterface(int, from, names)
@@ -32,40 +37,34 @@ const interfaceOverride = new Map<string, (int: ts.InterfaceDeclaration) => ts.N
 interfaceOverride.set('Event', createReplacer('vscode', ['Event']))
 interfaceOverride.set(
   'IActionDescriptor',
-  createReplacer('vs/editor/editor.api', ['editor', 'IActionDescriptor'])
+  createReplacer('monaco-editor', ['editor', 'IActionDescriptor'])
 )
-interfaceOverride.set(
-  'ICodeEditor',
-  createReplacer('vs/editor/editor.api', ['editor', 'ICodeEditor'])
-)
-interfaceOverride.set('IEditor', createReplacer('vs/editor/editor.api', ['editor', 'IEditor']))
-interfaceOverride.set(
-  'ITextModel',
-  createReplacer('vs/editor/editor.api', ['editor', 'ITextModel'])
-)
+interfaceOverride.set('ICodeEditor', createReplacer('monaco-editor', ['editor', 'ICodeEditor']))
+interfaceOverride.set('IEditor', createReplacer('monaco-editor', ['editor', 'IEditor']))
+interfaceOverride.set('ITextModel', createReplacer('monaco-editor', ['editor', 'ITextModel']))
 interfaceOverride.set(
   'IEditorOptions',
-  createReplacer('vs/editor/editor.api', ['editor', 'IEditorOptions'])
+  createReplacer('monaco-editor', ['editor', 'IEditorOptions'])
 )
 interfaceOverride.set(
   'IEditorOverrideServices',
-  createReplacer('vs/editor/editor.api', ['editor', 'IEditorOverrideServices'])
+  createReplacer('monaco-editor', ['editor', 'IEditorOverrideServices'])
 )
 interfaceOverride.set(
   'IStandaloneCodeEditor',
-  createReplacer('vs/editor/editor.api', ['editor', 'IStandaloneCodeEditor'])
+  createReplacer('monaco-editor', ['editor', 'IStandaloneCodeEditor'])
 )
 interfaceOverride.set(
   'IStandaloneDiffEditor',
-  createReplacer('vs/editor/editor.api', ['editor', 'IStandaloneDiffEditor'])
+  createReplacer('monaco-editor', ['editor', 'IStandaloneDiffEditor'])
 )
 interfaceOverride.set(
   'IStandaloneEditorConstructionOptions',
-  createReplacer('vs/editor/editor.api', ['editor', 'IStandaloneEditorConstructionOptions'])
+  createReplacer('monaco-editor', ['editor', 'IStandaloneEditorConstructionOptions'])
 )
 interfaceOverride.set(
   'IStandaloneDiffEditorConstructionOptions',
-  createReplacer('vs/editor/editor.api', ['editor', 'IStandaloneDiffEditorConstructionOptions'])
+  createReplacer('monaco-editor', ['editor', 'IStandaloneDiffEditorConstructionOptions'])
 )
 
 export function typeDedupReplaceTransformer(context: ts.TransformationContext) {
@@ -84,8 +83,7 @@ export function typeDedupReplaceTransformer(context: ts.TransformationContext) {
         const name = node.name.text
         const replacement = interfaceOverride.get(name)
         if (replacement != null) {
-          const nodeReplacement = replacement(node)
-          return nodeReplacement
+          return replacement(node)
         }
       }
       return ts.visitEachChild(node, typeDedupReplaceVisitor, context)


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/9eff375c-37c0-43cd-bb48-af58a9fee5d3)
![image](https://github.com/user-attachments/assets/19760d87-8b7e-40b0-9e19-d706b59d259d)


after:
![image](https://github.com/user-attachments/assets/46ce727c-8534-430e-ba66-b1282d160b93)
![image](https://github.com/user-attachments/assets/3cc25c48-f53d-4a82-ab68-4fe1ffd83069)

(missing export, and wrong monaco-editor path)

(it's red just because the screenshot is taken from the lib dist folder)

