### PR TITLE
Allow configuring extension host worker options

### DIFF
--- a/src/monaco.ts
+++ b/src/monaco.ts
@@ -81,6 +81,7 @@ export {
   EditorCommand
 } from 'vs/editor/browser/editorExtensions'
 export type { IEditorContribution, IDiffEditorContribution } from 'vs/editor/common/editorCommon'
+export type { ITextFileEditorModelSaveEvent } from 'vs/workbench/services/textfile/common/textfiles'
 
 function computeConfiguration(
   configuration: IEditorConfiguration,

--- a/vscode-patches/0060-feat-add-a-way-to-override-extension-host-config.patch
+++ b/vscode-patches/0060-feat-add-a-way-to-override-extension-host-config.patch
@@ -1,0 +1,137 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lo=C3=AFc=20Mangeonjean?= <loic@coderpad.io>
+Date: Tue, 11 Feb 2025 16:33:43 +0100
+Subject: [PATCH] feat: add a way to override extension host config
+
+---
+ .../services/extensions/browser/extensionService.ts   | 11 +++++++++--
+ .../extensions/browser/webWorkerExtensionHost.ts      |  5 ++++-
+ .../electron-sandbox/nativeExtensionService.ts        | 10 ++++++++--
+ .../worker/webWorkerExtensionHostIframe.html          | 10 +++++-----
+ 4 files changed, 26 insertions(+), 10 deletions(-)
+
+diff --git a/src/vs/workbench/services/extensions/browser/extensionService.ts b/src/vs/workbench/services/extensions/browser/extensionService.ts
+index cea72fd2225..c2aa0d65072 100644
+--- a/src/vs/workbench/services/extensions/browser/extensionService.ts
++++ b/src/vs/workbench/services/extensions/browser/extensionService.ts
+@@ -4,7 +4,7 @@
+  *--------------------------------------------------------------------------------------------*/
+ 
+ import { mainWindow } from '../../../../base/browser/window.js';
+-import { Schemas } from '../../../../base/common/network.js';
++import { FileAccess, Schemas } from '../../../../base/common/network.js';
+ import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+ import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+ import { ExtensionKind } from '../../../../platform/environment/common/environment.js';
+@@ -235,7 +235,14 @@ export class BrowserExtensionHostFactory implements IExtensionHostFactory {
+ 						? ExtensionHostStartup.EagerManualStart
+ 						: ExtensionHostStartup.EagerAutoStart
+ 				);
+-				return this._instantiationService.createInstance(WebWorkerExtensionHost, runningLocation, startup, this._createLocalExtensionHostDataProvider(runningLocations, runningLocation, isInitialStart));
++				return this._instantiationService.createInstance(
++					WebWorkerExtensionHost,
++					runningLocation,
++					startup,
++					this._createLocalExtensionHostDataProvider(runningLocations, runningLocation, isInitialStart),
++					FileAccess.asBrowserUri('vs/workbench/api/worker/extensionHostWorkerMain.js').toString(true),
++					{ type: 'module' }
++				);
+ 			}
+ 			case ExtensionHostKind.Remote: {
+ 				const remoteAgentConnection = this._remoteAgentService.getConnection();
+diff --git a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+index fb3c8cbfb57..eade34150d1 100644
+--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
++++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+@@ -59,6 +59,8 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
+ 		public readonly runningLocation: LocalWebWorkerRunningLocation,
+ 		public readonly startup: ExtensionHostStartup,
+ 		private readonly _initDataProvider: IWebWorkerExtensionHostDataProvider,
++		private readonly workerUrl: string,
++		private readonly workerOptions: WorkerOptions | undefined,
+ 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+ 		@IWorkspaceContextService private readonly _contextService: IWorkspaceContextService,
+ 		@ILabelService private readonly _labelService: ILabelService,
+@@ -184,7 +186,8 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
+ 				iframe.contentWindow!.postMessage({
+ 					type: event.data.type,
+ 					data: {
+-						workerUrl: FileAccess.asBrowserUri('vs/workbench/api/worker/extensionHostWorkerMain.js').toString(true),
++						workerUrl: this.workerUrl,
++						workerOptions: this.workerOptions,
+ 						fileRoot: globalThis._VSCODE_FILE_ROOT,
+ 						nls: {
+ 							messages: getNLSMessages(),
+diff --git a/src/vs/workbench/services/extensions/electron-sandbox/nativeExtensionService.ts b/src/vs/workbench/services/extensions/electron-sandbox/nativeExtensionService.ts
+index d38ab6b10ae..2dd06f6eef0 100644
+--- a/src/vs/workbench/services/extensions/electron-sandbox/nativeExtensionService.ts
++++ b/src/vs/workbench/services/extensions/electron-sandbox/nativeExtensionService.ts
+@@ -6,7 +6,7 @@
+ import { runWhenWindowIdle } from '../../../../base/browser/dom.js';
+ import { mainWindow } from '../../../../base/browser/window.js';
+ import { CancellationToken } from '../../../../base/common/cancellation.js';
+-import { Schemas } from '../../../../base/common/network.js';
++import { FileAccess, Schemas } from '../../../../base/common/network.js';
+ import * as performance from '../../../../base/common/performance.js';
+ import { isCI } from '../../../../base/common/platform.js';
+ import { URI } from '../../../../base/common/uri.js';
+@@ -552,7 +552,13 @@ class NativeExtensionHostFactory implements IExtensionHostFactory {
+ 							? (this._webWorkerExtHostEnablement === LocalWebWorkerExtHostEnablement.Lazy ? ExtensionHostStartup.Lazy : ExtensionHostStartup.EagerManualStart)
+ 							: ExtensionHostStartup.EagerAutoStart
+ 					);
+-					return this._instantiationService.createInstance(WebWorkerExtensionHost, runningLocation, startup, this._createWebWorkerExtensionHostDataProvider(runningLocations, runningLocation));
++					return this._instantiationService.createInstance(
++						WebWorkerExtensionHost,
++						runningLocation,
++						startup,
++						this._createWebWorkerExtensionHostDataProvider(runningLocations, runningLocation),
++						FileAccess.asBrowserUri('vs/workbench/api/worker/extensionHostWorkerMain.js').toString(true),
++						{ type: 'module' });
+ 				}
+ 				return null;
+ 			}
+diff --git a/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html b/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+index eff43dcde6c..59a3292e302 100644
+--- a/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
++++ b/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
+@@ -4,7 +4,7 @@
+ 		<meta http-equiv="Content-Security-Policy" content="
+ 			default-src 'none';
+ 			child-src 'self' data: blob:;
+-			script-src 'self' 'unsafe-eval' 'sha256-xM2KVDKIoeb8vVxk4ezEUsxdTZh5wFnKO3YmFhy9tkk=' data: extension-file: https: http://localhost:* blob:;
++			script-src 'self' 'unsafe-eval' 'sha256-O8NK++6jfjVooqQN8mkcEKUM19Yc4nx5RZXws6U2sao=' data: extension-file: https: http://localhost:* blob:;
+ 			connect-src 'self' data: extension-file: https: wss: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*;"/>
+ 	</head>
+ 	<body>
+@@ -78,7 +78,7 @@
+ 				return;
+ 			}
+ 			const { data } = event.data;
+-			createWorker(data.workerUrl, data.fileRoot, data.nls.messages, data.nls.language);
++			createWorker(data.workerUrl, data.workerOptions, data.fileRoot, data.nls.messages, data.nls.language);
+ 		};
+ 
+ 		window.parent.postMessage({
+@@ -87,7 +87,7 @@
+ 		}, '*');
+ 	}
+ 
+-	function createWorker(workerUrl, fileRoot, nlsMessages, nlsLanguage) {
++	function createWorker(workerUrl, workerOptions, fileRoot, nlsMessages, nlsLanguage) {
+ 		try {
+ 			if (globalThis.crossOriginIsolated) {
+ 				workerUrl += '?vscode-coi=2'; // COEP
+@@ -102,11 +102,11 @@
+ 				`globalThis._VSCODE_NLS_MESSAGES = ${JSON.stringify(nlsMessages)};`,
+ 				`globalThis._VSCODE_NLS_LANGUAGE = ${JSON.stringify(nlsLanguage)};`,
+ 				`globalThis._VSCODE_FILE_ROOT = ${JSON.stringify(fileRoot)};`,
+-				`await import(${JSON.stringify(workerUrl)});`,
++				(workerOptions.type === 'module') ? `await import('${workerUrl}');` : `importScripts('${workerUrl}');`,
+ 				`/*extensionHostWorker*/`
+ 			].join('')], { type: 'application/javascript' });
+ 
+-			const worker = new Worker(URL.createObjectURL(blob), { name, type: 'module' });
++			const worker = new Worker(URL.createObjectURL(blob), { name, ...workerOptions });
+ 			const nestedWorkers = new Map();
+ 
+ 			worker.onmessage = (event) => {


### PR DESCRIPTION
It was removed during a VSCode refactor removing non-ESM code. But we do need to support non-esm workers for webpack