### PR TITLE
Fix extension host worker when used with a cdn

### DIFF
--- a/src/service-override/extensions.ts
+++ b/src/service-override/extensions.ts
@@ -291,7 +291,7 @@ class ExtensionResourceLoaderServiceOverride extends ExtensionResourceLoaderServ
   }
 }
 
-let iframeAlternateDomains: string | undefined
+let iframeAlternateDomain: string | undefined
 registerAssets({
   'vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html': () =>
     changeUrlDomain(
@@ -299,22 +299,22 @@ registerAssets({
         '../../vscode/src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html',
         import.meta.url
       ).href,
-      iframeAlternateDomains
+      iframeAlternateDomain
     )
 })
 
 export default function getServiceOverride(
   workerConfig?: WorkerConfig,
-  _iframeAlternateDomains?: string
+  _iframeAlternateDomain?: string
 ): IEditorOverrideServices {
-  if (_iframeAlternateDomains != null) {
-    iframeAlternateDomains = _iframeAlternateDomains
+  if (_iframeAlternateDomain != null) {
+    iframeAlternateDomain = _iframeAlternateDomain
   }
   const _workerConfig =
     workerConfig != null
       ? {
           ...workerConfig,
-          url: changeUrlDomain(workerConfig.url, iframeAlternateDomains)
+          url: changeUrlDomain(workerConfig.url, iframeAlternateDomain ?? globalThis.location?.href ?? import.meta.url)
         }
       : undefined
 

--- a/vscode-patches/0061-fix-always-set-parent-origin.patch
+++ b/vscode-patches/0061-fix-always-set-parent-origin.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lo=C3=AFc=20Mangeonjean?= <loic@coderpad.io>
+Date: Tue, 11 Feb 2025 19:59:40 +0100
+Subject: [PATCH] fix: always set parent origin
+
+---
+ .../services/extensions/browser/webWorkerExtensionHost.ts       | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+index eade34150d1..95106926e93 100644
+--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
++++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+@@ -85,6 +85,7 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
+ 			suffixSearchParams.set('debugged', '1');
+ 		}
+ 		COI.addSearchParam(suffixSearchParams, true, true);
++		suffixSearchParams.set('parentOrigin', mainWindow.origin);
+ 
+ 		const suffix = `?${suffixSearchParams.toString()}`;
+ 
+@@ -110,7 +111,6 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
+ 				);
+ 
+ 				const res = new URL(`${baseUrl}/out/${iframeModulePath}${suffix}`);
+-				res.searchParams.set('parentOrigin', mainWindow.origin);
+ 				res.searchParams.set('salt', stableOriginUUID);
+ 				return res.toString();
+ 			}


### PR DESCRIPTION
If the extension host iframe is hosted on another domain, it refuses messages from the main thread because the domain does not match. VSCode handle this by adding a `parentOrigin` parameter but in our case it wasn't used

Also, force set the domain of the extension host worker, it was the case before a previous refactor and is a regression, forcing us to set the webpack `publicPath` for it to work, or provide a `iframeAlternateDomain` by hands