### PR TITLE
remove unwanted classes from body

### DIFF
--- a/src/service-override/layout.ts
+++ b/src/service-override/layout.ts
@@ -70,8 +70,6 @@ export class LayoutService extends Disposable implements ILayoutService, IWorkbe
     ])
 
     mainContainer.classList.add(...workbenchClasses)
-    document.body.classList.add(platformClass)
-    document.body.classList.add('web')
   }
 
   getSize(part: Parts): IViewSize {


### PR DESCRIPTION
There is no need to add extra classes to the body, as these classes are specific to the editor area.
Otherwise, they pollute the `body` unless you attach the editor directly below the body.

So we only need to attach 'web' and platformClass to `mainContainer`. And that is already done in the line above.