### PR TITLE
Fix quickinput standalone position

### DIFF
--- a/vscode-patches/0062-fix-fix-standalone-editor-quick-input-location.patch
+++ b/vscode-patches/0062-fix-fix-standalone-editor-quick-input-location.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lo=C3=AFc=20Mangeonjean?= <loic@coderpad.io>
+Date: Mon, 3 Mar 2025 15:10:33 +0100
+Subject: [PATCH] fix: fix standalone editor quick input location
+
+---
+ .../browser/quickInput/standaloneQuickInputService.ts         | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputService.ts b/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputService.ts
+index 91f910e3776..ee712836bca 100644
+--- a/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputService.ts
++++ b/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputService.ts
+@@ -5,7 +5,7 @@
+ 
+ import './standaloneQuickInput.css';
+ import { Event } from '../../../../base/common/event.js';
+-import { ICodeEditor, IOverlayWidget, IOverlayWidgetPosition, OverlayWidgetPositionPreference } from '../../../browser/editorBrowser.js';
++import { ICodeEditor, IOverlayWidget, IOverlayWidgetPosition } from '../../../browser/editorBrowser.js';
+ import { EditorContributionInstantiation, registerEditorContribution } from '../../../browser/editorExtensions.js';
+ import { IEditorContribution } from '../../../common/editorCommon.js';
+ import { IThemeService } from '../../../../platform/theme/common/themeService.js';
+@@ -200,7 +200,7 @@ export class QuickInputEditorWidget implements IOverlayWidget {
+ 	}
+ 
+ 	getPosition(): IOverlayWidgetPosition | null {
+-		return { preference: OverlayWidgetPositionPreference.TOP_CENTER };
++		return { preference: null };
+ 	}
+ 
+ 	dispose(): void {


### PR DESCRIPTION
Microsoft doesn't seem to be releasing monaco-editor anymore :thinking: 

They broke the standalone quickinput location while implementing the ability to move it in the workbench

I'm not sure what is the proper fix to it, but at least  that MR seems to be restoring the previous behavior