### PR TITLE
Vscode 1.99.2 + standalone worker fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   },
   "config": {
     "vscode": {
-      "version": "1.99.1",
-      "ref": "1.99.1",
-      "commit": "7c6fdfb0b8f2f675eb0b47f3d95eeca78962565b"
+      "version": "1.99.2",
+      "ref": "1.99.2",
+      "commit": "4949701c880d4bdb949e3c0e6b400288da7f474b"
     },
     "monaco": {
       "ref": "v0.52.2",

--- a/src/editor.api.ts
+++ b/src/editor.api.ts
@@ -6,7 +6,14 @@ import {
   writeFile
 } from './monaco'
 import { withReadyServices } from './services'
+import type {
+  IInternalWebWorkerOptions,
+  MonacoWebWorker
+} from 'vs/editor/standalone/browser/standaloneWebWorker'
+import { URI } from 'vs/base/common/uri'
+import type { IWebWorkerDescriptor } from 'vs/base/browser/webWorkerFactory'
 export * from 'vs/editor/editor.api'
+import { createWebWorker as actualCreateWebWorker } from 'vs/editor/standalone/browser/standaloneEditor.js'
 
 declare module 'vs/editor/editor.api' {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -25,3 +32,93 @@ editor.create = createConfiguredEditor as unknown as typeof editor.create
 editor.createDiffEditor = createConfiguredDiffEditor as unknown as typeof editor.createDiffEditor
 editor.createModelReference = createModelReference
 editor.writeFile = writeFile
+
+/**
+ * Make the `createWebWorker` method backward compatible, until the monaco standalone workers are updated
+ */
+export interface IWebWorkerOptions {
+  /**
+   * The AMD moduleId to load.
+   * It should export a function `create` that should return the exported proxy.
+   */
+  moduleId: string
+  /**
+   * The data to send over when calling create on the module.
+   */
+  createData?: unknown
+  /**
+   * A label to be used to identify the web worker for debugging purposes.
+   */
+  label?: string
+  /**
+   * An object that can be used by the web worker to make calls back to the main thread.
+   */
+  host?: unknown
+  /**
+   * Keep idle models.
+   * Defaults to false, which means that idle models will stop syncing after a while.
+   */
+  keepIdleModels?: boolean
+}
+
+let id = 0
+function getWorker(descriptor: IWebWorkerDescriptor): Worker {
+  const label = descriptor.label || 'anonymous' + ++id
+
+  // Option for hosts to overwrite the worker script (used in the standalone editor)
+  interface IMonacoEnvironment {
+    getWorker?(moduleId: string, label: string): Worker
+    getWorkerUrl?(moduleId: string, label: string): string
+  }
+  const monacoEnvironment: IMonacoEnvironment | undefined = (
+    globalThis as unknown as { MonacoEnvironment: IMonacoEnvironment }
+  ).MonacoEnvironment
+  if (monacoEnvironment) {
+    if (typeof monacoEnvironment.getWorker === 'function') {
+      return monacoEnvironment.getWorker('workerMain.js', label)
+    }
+    if (typeof monacoEnvironment.getWorkerUrl === 'function') {
+      const workerUrl = monacoEnvironment.getWorkerUrl('workerMain.js', label)
+      return new Worker(workerUrl, { name: label, type: 'module' })
+    }
+  }
+
+  throw new Error(
+    `You must define a function MonacoEnvironment.getWorkerUrl or MonacoEnvironment.getWorker`
+  )
+}
+
+function isIWebWorkerOptions(
+  options: IWebWorkerOptions | IInternalWebWorkerOptions
+): options is IWebWorkerOptions {
+  return 'moduleId' in options
+}
+
+const originalCreateWebWorker = editor.createWebWorker
+export function createWebWorker<T extends object>(
+  options: IWebWorkerOptions | IInternalWebWorkerOptions
+): MonacoWebWorker<T> {
+  if (isIWebWorkerOptions(options)) {
+    const worker = getWorker({
+      esmModuleLocation: URI.parse(options.moduleId),
+      label: options.label
+    })
+
+    const webworker = actualCreateWebWorker<T>({
+      worker,
+      host: options.host,
+      keepIdleModels: options.keepIdleModels
+    })
+
+    void (async () => {
+      const proxy = await webworker.getProxy()
+      ;(proxy as { $initialize: (data: unknown) => Promise<void> }).$initialize(options.createData)
+    })()
+
+    return webworker
+  } else {
+    return originalCreateWebWorker(options)
+  }
+}
+
+editor.createWebWorker = createWebWorker

--- a/src/workers/editor.worker.ts
+++ b/src/workers/editor.worker.ts
@@ -1,1 +1,29 @@
-export * from 'vs/editor/common/services/editorWebWorkerMain.js'
+import 'vs/editor/common/services/editorWebWorkerMain.js'
+import { start } from 'vs/editor/editor.worker.start'
+import type { IWorkerContext } from 'vs/editor/common/services/editorWebWorker'
+
+/**
+ * Make the `initialize` method backward compatible, until the monaco standalone workers are updated
+ */
+
+type CreateFunction<D, R extends object = object> = (ctx: IWorkerContext<object>, data: D) => R
+export function initialize<D, R extends object>(createFn: CreateFunction<D, R>) {
+  let requestHandler: R | undefined
+  const foreignModule = new Proxy(
+    {},
+    {
+      get(_target, propKey: PropertyKey) {
+        if (propKey === '$initialize') {
+          return async (data: D) => {
+            if (!requestHandler) {
+              requestHandler = createFn(context, data)
+            }
+          }
+        }
+        return requestHandler?.[propKey as keyof R]
+      }
+    }
+  )
+
+  const context = start(foreignModule)
+}

--- a/vscode-patches/0063-fix-prevent-proxy-from-being-detected-as-a-promise.patch
+++ b/vscode-patches/0063-fix-prevent-proxy-from-being-detected-as-a-promise.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lo=C3=AFc=20Mangeonjean?= <loic@coderpad.io>
+Date: Fri, 11 Apr 2025 15:19:20 +0200
+Subject: [PATCH] fix: prevent proxy from being detected as a promise
+
+---
+ src/vs/editor/standalone/browser/standaloneWebWorker.ts | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/vs/editor/standalone/browser/standaloneWebWorker.ts b/src/vs/editor/standalone/browser/standaloneWebWorker.ts
+index f8aa5966d51..cc2307dc4e8 100644
+--- a/src/vs/editor/standalone/browser/standaloneWebWorker.ts
++++ b/src/vs/editor/standalone/browser/standaloneWebWorker.ts
+@@ -64,6 +64,10 @@ class MonacoWebWorkerImpl<T extends object> extends EditorWorkerClient implement
+ 					if (typeof prop !== 'string') {
+ 						throw new Error(`Not supported`);
+ 					}
++					// `then` property existing may be checked to see if the object is a promise, so force return undefined
++					if (prop === 'then') {
++						return undefined;
++					}
+ 					return (...args: any[]) => {
+ 						return proxy.$fmr(prop, args);
+ 					};


### PR DESCRIPTION
in the v1.99, the monaco worker api was drastically changed. Yet no according monaco update was published or even developped on a branch somewhere.

This MR includes an attempt to make sure the exposed worker api is backward compatible with the one used in the html/css/typescript standalone workers

Also includes the update to the 1.99.2

fix for https://github.com/CodinGame/monaco-vscode-api/discussions/607