### PR TITLE
[FIX] Properly inject product configuration

### DIFF
--- a/rollup/rollup.config.ts
+++ b/rollup/rollup.config.ts
@@ -125,7 +125,7 @@ export default (args: Record<string, string>): rollup.RollupOptions => {
         external,
         transformers: [typeDedupReplaceTransformer]
       }),
-      resolveVscodePlugin(),
+      resolveVscodePlugin(vscodeVersion, vscodeCommit),
       vscodeLocalizationPlugin(),
       typescript({
         noEmitOnError: true,
@@ -148,9 +148,6 @@ export default (args: Record<string, string>): rollup.RollupOptions => {
         }
       }),
       replace({
-        VSCODE_VERSION: JSON.stringify(vscodeVersion),
-        VSCODE_REF: JSON.stringify(vscodeRef),
-        VSCODE_COMMIT: JSON.stringify(vscodeCommit),
         BUILD_ID: JSON.stringify(`${vscodeRef}-${crypto.randomUUID()}`),
         'globalThis.require': 'undefined',
         preventAssignment: true

--- a/scripts/install-vscode
+++ b/scripts/install-vscode
@@ -81,7 +81,7 @@ NODE_OPTIONS=--max-old-space-size=8192 npx tsc --declaration --importHelpers --o
 find ./ \( -name '*.js' -o -name '*.d.ts' -o -name '*.ttf' -o -name '*.css' -o -name '*.mp3' -o -name '*.scm' -o -name '*.svg' -o -name '*.png' -o -name '*.html' -o -name '*.sh' -o -name '*.zsh' -o -name '*.ps1' \) -exec rsync -R \{\} "$output_directory/src" \;
 
 cd ..
-cp package.json $output_directory
+cp package.json product.json $output_directory
 # Copy editor types
 cp out-monaco-editor-core/esm/vs/editor/editor.api.d.ts $output_directory/src/vs/editor/editor.api.d.ts
 

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -23,6 +23,7 @@ import * as editorOptions from 'vs/editor/common/config/editorOptions'
 import * as uri from 'vs/base/common/uri'
 import * as telemetry from 'vs/platform/telemetry/common/telemetryUtils'
 import { defaultApi } from './localExtensionHost.js'
+import deprecatedProduct from 'vs/platform/product/common/product'
 
 function createProxy<T extends keyof typeof vscode>(key: T): (typeof vscode)[T] {
   return new Proxy(
@@ -42,7 +43,7 @@ function createProxy<T extends keyof typeof vscode>(key: T): (typeof vscode)[T] 
 }
 
 const api: typeof vscode = {
-  version: VSCODE_VERSION,
+  version: deprecatedProduct.version,
   tasks: createProxy('tasks'),
   notebooks: createProxy('notebooks'),
   scm: createProxy('scm'),

--- a/src/missing-services.ts
+++ b/src/missing-services.ts
@@ -1342,8 +1342,8 @@ registerSingleton(IPathService, PathService, InstantiationType.Delayed)
 class ProductService implements IProductService {
   readonly _serviceBrand = undefined
 
-  version = VSCODE_VERSION
-  commit = VSCODE_COMMIT
+  version = 'unknown'
+  commit = 'unknown'
   quality = 'oss'
   nameShort = 'Code - OSS Dev'
   nameLong = 'Code - OSS Dev'

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,3 @@
-declare const VSCODE_VERSION: string
-declare const VSCODE_REF: string
-declare const VSCODE_COMMIT: string
 declare const BUILD_ID: string
 
 declare module 'vs/platform/accessibilitySignal/browser/media/*.mp3' {


### PR DESCRIPTION
even in deprecated field, and initialize with the whole default product.json

(It looks like I didn't fix it properly, a deprecated field is used and needs to be initialized)