### PR TITLE
Vscode 1.100.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   },
   "config": {
     "vscode": {
-      "version": "1.100.0",
-      "ref": "1.100.0",
-      "commit": "19e0f9e681ecb8e5c09d8784acaa601316ca4571"
+      "version": "1.100.1",
+      "ref": "1.100.1",
+      "commit": "512333e1dda3ed8cc90d7893ba91b596765e71c0"
     },
     "monaco": {
       "ref": "v0.52.2",

--- a/rollup/rollup.config.ts
+++ b/rollup/rollup.config.ts
@@ -30,6 +30,7 @@ import {
   VSCODE_SRC_DIR
 } from './tools/config.js'
 import { transformImportEqualsTransformerFactory } from './tools/typescript.js'
+import json from '@rollup/plugin-json'
 
 const input = {
   'extension.api': './src/extension.api.ts',
@@ -158,7 +159,13 @@ export default (args: Record<string, string>): rollup.RollupOptions => {
       }),
       dynamicImportPolyfillPlugin(),
       dynamicImportVars({
+        include: ['**/*.ts', '**/*.js'],
         exclude: ['**/amdX.js']
+      }),
+      json({
+        compact: true,
+        namedExports: false,
+        preferConst: false
       }),
       {
         name: 'cleanup',


### PR DESCRIPTION
Also support overriding the base product configuration using the `_VSCODE_PRODUCT_JSON` global variable

Some code from VSCode relies on it and ignore the product override, like the default chat configuration