### PR TITLE
Register language pack extension

### DIFF
--- a/rollup/rollup.language-packs.ts
+++ b/rollup/rollup.language-packs.ts
@@ -89,7 +89,9 @@ export default rollup.defineConfig([
                 return `
 import { registerLocalization } from '${MAIN_PACKAGE_NAME}/l10n'
 import content from '${path.resolve(id, mainTranslation.path)}'
-registerLocalization('${packageJson.publisher}.${packageJson.name}', '${mainLocalization.languageId}', content, {
+
+const manifest = ${JSON.stringify(packageJson)}
+registerLocalization(manifest, '${mainLocalization.languageId}', content, {
 ${Object.entries(translationAssets)
   .map(
     ([id, assetRef]) =>

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -44,7 +44,7 @@ import {
 } from './service-override/files'
 import { waitServicesReady } from './lifecycle'
 import { throttle } from './tools'
-import { getBuiltInExtensionTranslationsUris } from './l10n'
+import { getBuiltInExtensionTranslationsUris, getLocalizationManifest } from './l10n'
 
 export type ApiFactory = (extensionId?: string) => Promise<typeof vscode>
 
@@ -291,6 +291,11 @@ export function registerExtension(
   }
 
   return api
+}
+
+const localizationManifest = getLocalizationManifest()
+if (localizationManifest != null) {
+  registerExtension(localizationManifest, ExtensionHostKind.LocalWebWorker, { system: true })
 }
 
 export { ExtensionHostKind }

--- a/src/l10n.ts
+++ b/src/l10n.ts
@@ -1,4 +1,5 @@
 import { isInitialized } from 'vs/nls'
+import type { IExtensionManifest } from './extensions'
 
 const extensionTranslationsUri: Record<string, Record<string, string>> = {}
 let currentLocaleExtensionId: string | undefined
@@ -18,17 +19,16 @@ declare global {
    * under `src/vs` translated to the language as indicated by
    * `_VSCODE_NLS_LANGUAGE`.
    */
-  // eslint-disable-next-line no-var
   var _VSCODE_NLS_MESSAGES: string[]
   /**
    * The actual language of the NLS messages (e.g. 'en', de' or 'pt-br').
    */
-  // eslint-disable-next-line no-var
   var _VSCODE_NLS_LANGUAGE: string | undefined
 }
 
+let localizationManifest: IExtensionManifest | undefined
 function registerLocalization(
-  extensionId: string,
+  manifest: IExtensionManifest,
   language: string,
   main: string[],
   extensionTranslationsUris: Record<string, string>
@@ -42,7 +42,9 @@ function registerLocalization(
   globalThis._VSCODE_NLS_LANGUAGE = language
 
   extensionTranslationsUri[language] = extensionTranslationsUris
-  currentLocaleExtensionId = extensionId
+  currentLocaleExtensionId = `${manifest.publisher}.${manifest.name}`
+
+  localizationManifest = manifest
 }
 
 function getBuiltInExtensionTranslationsUris(language: string): Record<string, string> | undefined {
@@ -53,10 +55,15 @@ function getExtensionIdProvidingCurrentLocale(): string | undefined {
   return currentLocaleExtensionId
 }
 
+function getLocalizationManifest(): IExtensionManifest | undefined {
+  return localizationManifest
+}
+
 export {
   registerLocalization,
   getBuiltInExtensionTranslationsUris,
   getExtensionIdProvidingCurrentLocale,
+  getLocalizationManifest,
   setAvailableLocales,
   isLocaleAvailable
 }

--- a/src/services.ts
+++ b/src/services.ts
@@ -350,3 +350,283 @@ export type {
   ServicesAccessor
 }
 export { ConfigurationTarget } from 'vs/platform/configuration/common/configuration'
+export { IRemoteExplorerService } from 'vs/workbench/services/remote/common/remoteExplorerService.service'
+export { ITunnelService } from 'vs/platform/tunnel/common/tunnel.service'
+
+export { ITreeViewsDnDService } from 'vs/editor/common/services/treeViewsDndService.service'
+export { IAccessibleViewService } from 'vs/platform/accessibility/browser/accessibleView.service'
+export { IActionViewItemService } from 'vs/platform/actions/browser/actionViewItemService.service'
+export { IExtensionHostDebugService } from 'vs/platform/debug/common/extensionHostDebug.service'
+export { NullDiagnosticsService } from 'vs/platform/diagnostics/common/diagnostics'
+export { IDiagnosticsService } from 'vs/platform/diagnostics/common/diagnostics.service'
+export { IDownloadService } from 'vs/platform/download/common/download.service'
+export { IEncryptionService } from 'vs/platform/encryption/common/encryptionService.service'
+export { IEnvironmentService } from 'vs/platform/environment/common/environment.service'
+export {
+  IAllowedExtensionsService,
+  IExtensionGalleryService,
+  IExtensionTipsService,
+  IGlobalExtensionEnablementService
+} from 'vs/platform/extensionManagement/common/extensionManagement.service'
+export { IExtensionStorageService } from 'vs/platform/extensionManagement/common/extensionStorage.service'
+export { IExtensionsProfileScannerService } from 'vs/platform/extensionManagement/common/extensionsProfileScannerService.service'
+export { IExtensionsScannerService } from 'vs/platform/extensionManagement/common/extensionsScannerService.service'
+export { IExtensionRecommendationNotificationService } from 'vs/platform/extensionRecommendations/common/extensionRecommendations.service'
+export { IExtensionResourceLoaderService } from 'vs/platform/extensionResourceLoader/common/extensionResourceLoader.service'
+export { IBuiltinExtensionsScannerService } from 'vs/platform/extensions/common/extensions.service'
+export { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions'
+export { IKeyboardLayoutService } from 'vs/platform/keyboardLayout/common/keyboardLayout.service'
+export { NullPolicyService } from 'vs/platform/policy/common/policy'
+export { IPolicyService } from 'vs/platform/policy/common/policy.service'
+export { IRemoteExtensionsScannerService } from 'vs/platform/remote/common/remoteExtensionsScanner.service'
+export { IRequestService } from 'vs/platform/request/common/request.service'
+export { ISignService } from 'vs/platform/sign/common/sign.service'
+export { ICustomEndpointTelemetryService } from 'vs/platform/telemetry/common/telemetry.service'
+export { NullEndpointTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils'
+export { TerminalLocation } from 'vs/platform/terminal/common/terminal'
+export { ITerminalLogService } from 'vs/platform/terminal/common/terminal.service'
+export { State } from 'vs/platform/update/common/update'
+export { IUpdateService } from 'vs/platform/update/common/update.service'
+export { UriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentityService'
+export { IURLService } from 'vs/platform/url/common/url.service'
+export { toUserDataProfile } from 'vs/platform/userDataProfile/common/userDataProfile'
+export { IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile.service'
+export { IUserDataProfileStorageService } from 'vs/platform/userDataProfile/common/userDataProfileStorageService.service'
+export { IIgnoredExtensionsManagementService } from 'vs/platform/userDataSync/common/ignoredExtensions.service'
+export {
+  IUserDataAutoSyncService,
+  IUserDataSyncEnablementService,
+  IUserDataSyncLocalStoreService,
+  IUserDataSyncLogService,
+  IUserDataSyncResourceProviderService,
+  IUserDataSyncService,
+  IUserDataSyncStoreManagementService,
+  IUserDataSyncStoreService,
+  IUserDataSyncUtilService
+} from 'vs/platform/userDataSync/common/userDataSync.service'
+export { IUserDataSyncAccountService } from 'vs/platform/userDataSync/common/userDataSyncAccount.service'
+export { IUserDataSyncMachinesService } from 'vs/platform/userDataSync/common/userDataSyncMachines.service'
+export { ICanonicalUriService } from 'vs/platform/workspace/common/canonicalUri.service'
+export { IEditSessionIdentityService } from 'vs/platform/workspace/common/editSessions.service'
+export { WorkspaceTrustUriResponse } from 'vs/platform/workspace/common/workspaceTrust'
+export { IWorkspacesService } from 'vs/platform/workspaces/common/workspaces.service'
+export {
+  type ExtensionStatusBarEntry,
+  IExtensionStatusBarItemService,
+  StatusBarUpdateKind
+} from 'vs/workbench/api/browser/statusBarService'
+export {
+  DEFAULT_EDITOR_PART_OPTIONS,
+  type IEditorGroupView
+} from 'vs/workbench/browser/parts/editor/editor'
+export {
+  IChatAccessibilityService,
+  IChatCodeBlockContextProviderService,
+  IChatWidgetService,
+  IQuickChatService
+} from 'vs/workbench/contrib/chat/browser/chat.service'
+export {
+  IChatAgentNameService,
+  IChatAgentService
+} from 'vs/workbench/contrib/chat/common/chatAgents.service'
+export { ICodeMapperService } from 'vs/workbench/contrib/chat/common/chatCodeMapperService.service'
+export { IChatEditingService } from 'vs/workbench/contrib/chat/common/chatEditingService.service'
+export { IChatService } from 'vs/workbench/contrib/chat/common/chatService.service'
+export { IChatSlashCommandService } from 'vs/workbench/contrib/chat/common/chatSlashCommands.service'
+export { IChatVariablesService } from 'vs/workbench/contrib/chat/common/chatVariables.service'
+export { IChatWidgetHistoryService } from 'vs/workbench/contrib/chat/common/chatWidgetHistoryService.service'
+export { ILanguageModelIgnoredFilesService } from 'vs/workbench/contrib/chat/common/ignoredFiles.service'
+export { ILanguageModelStatsService } from 'vs/workbench/contrib/chat/common/languageModelStats.service'
+export { ILanguageModelToolsService } from 'vs/workbench/contrib/chat/common/languageModelToolsService.service'
+export { ILanguageModelsService } from 'vs/workbench/contrib/chat/common/languageModels.service'
+export { ICommentService } from 'vs/workbench/contrib/comments/browser/commentService.service'
+export { ICustomEditorService } from 'vs/workbench/contrib/customEditor/common/customEditor.service'
+export { IDebugVisualizerService } from 'vs/workbench/contrib/debug/common/debugVisualizers.service'
+export {
+  IEditSessionsLogService,
+  IEditSessionsStorageService
+} from 'vs/workbench/contrib/editSessions/common/editSessions.service'
+export { IExtensionsWorkbenchService } from 'vs/workbench/contrib/extensions/common/extensions.service'
+export { IExternalUriOpenerService } from 'vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService.service'
+export { IInlineChatSessionService } from 'vs/workbench/contrib/inlineChat/browser/inlineChatSessionService.service'
+export { IInteractiveDocumentService } from 'vs/workbench/contrib/interactive/browser/interactiveDocumentService.service'
+export { IInteractiveHistoryService } from 'vs/workbench/contrib/interactive/browser/interactiveHistoryService.service'
+export { ITroubleshootIssueService } from 'vs/workbench/contrib/issue/browser/issueTroubleshoot.service'
+export {
+  IIssueFormService,
+  IWorkbenchIssueService
+} from 'vs/workbench/contrib/issue/common/issue.service'
+export { IDefaultLogLevelsService } from 'vs/workbench/contrib/logs/common/defaultLogLevels.service'
+export { IMultiDiffSourceResolverService } from 'vs/workbench/contrib/multiDiffEditor/browser/multiDiffSourceResolverService.service'
+export { INotebookOriginalCellModelFactory } from 'vs/workbench/contrib/notebook/browser/diff/inlineDiff/notebookOriginalCellModelFactory.service'
+export { INotebookOriginalModelReferenceFactory } from 'vs/workbench/contrib/notebook/browser/diff/inlineDiff/notebookOriginalModelRefFactory.service'
+export { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService.service'
+export { INotebookCellStatusBarService } from 'vs/workbench/contrib/notebook/common/notebookCellStatusBarService.service'
+export { INotebookEditorModelResolverService } from 'vs/workbench/contrib/notebook/common/notebookEditorModelResolverService.service'
+export { INotebookExecutionService } from 'vs/workbench/contrib/notebook/common/notebookExecutionService.service'
+export { INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService.service'
+export {
+  INotebookKernelHistoryService,
+  INotebookKernelService
+} from 'vs/workbench/contrib/notebook/common/notebookKernelService.service'
+export { INotebookKeymapService } from 'vs/workbench/contrib/notebook/common/notebookKeymapService.service'
+export { INotebookLoggingService } from 'vs/workbench/contrib/notebook/common/notebookLoggingService.service'
+export { INotebookRendererMessagingService } from 'vs/workbench/contrib/notebook/common/notebookRendererMessagingService.service'
+export { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService.service'
+export { INotebookEditorWorkerService } from 'vs/workbench/contrib/notebook/common/services/notebookWorkerService.service'
+export { IQuickDiffModelService } from 'vs/workbench/contrib/scm/browser/quickDiffModel.service'
+export { IQuickDiffService } from 'vs/workbench/contrib/scm/common/quickDiff.service'
+export { ISCMService, ISCMViewService } from 'vs/workbench/contrib/scm/common/scm.service'
+export { IReplaceService } from 'vs/workbench/contrib/search/browser/replace.service'
+export { ISearchViewModelWorkbenchService } from 'vs/workbench/contrib/search/browser/searchTreeModel/searchViewModelWorkbenchService.service'
+export { INotebookSearchService } from 'vs/workbench/contrib/search/common/notebookSearch.service'
+export { ISearchHistoryService } from 'vs/workbench/contrib/search/common/searchHistoryService.service'
+export { IShareService } from 'vs/workbench/contrib/share/common/share.service'
+export { ISpeechService } from 'vs/workbench/contrib/speech/common/speechService.service'
+export { NoOpWorkspaceTagsService } from 'vs/workbench/contrib/tags/browser/workspaceTagsService'
+export { IWorkspaceTagsService } from 'vs/workbench/contrib/tags/common/workspaceTags.service'
+export { ITaskService } from 'vs/workbench/contrib/tasks/common/taskService.service'
+export {
+  ITerminalConfigurationService,
+  ITerminalEditorService,
+  ITerminalGroupService,
+  ITerminalInstanceService,
+  ITerminalService
+} from 'vs/workbench/contrib/terminal/browser/terminal.service'
+export { IEnvironmentVariableService } from 'vs/workbench/contrib/terminal/common/environmentVariable.service'
+export {
+  ITerminalProfileResolverService,
+  ITerminalProfileService
+} from 'vs/workbench/contrib/terminal/common/terminal.service'
+export { ITerminalContributionService } from 'vs/workbench/contrib/terminal/common/terminalExtensionPoints.service'
+export { ITerminalLinkProviderService } from 'vs/workbench/contrib/terminalContrib/links/browser/links.service'
+export { ITerminalQuickFixService } from 'vs/workbench/contrib/terminalContrib/quickFix/browser/quickFix.service'
+export { ITerminalCompletionService } from 'vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.service'
+export { ITestCoverageService } from 'vs/workbench/contrib/testing/common/testCoverageService.service'
+export { ITestExplorerFilterState } from 'vs/workbench/contrib/testing/common/testExplorerFilterState.service'
+export { ITestProfileService } from 'vs/workbench/contrib/testing/common/testProfileService.service'
+export { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService.service'
+export { ITestResultStorage } from 'vs/workbench/contrib/testing/common/testResultStorage.service'
+export { ITestService } from 'vs/workbench/contrib/testing/common/testService.service'
+export { ITestingContinuousRunService } from 'vs/workbench/contrib/testing/common/testingContinuousRunService.service'
+export { ITestingDecorationsService } from 'vs/workbench/contrib/testing/common/testingDecorations.service'
+export { ITestingPeekOpener } from 'vs/workbench/contrib/testing/common/testingPeekOpener.service'
+export { ITimelineService } from 'vs/workbench/contrib/timeline/common/timeline.service'
+export { ITrustedDomainService } from 'vs/workbench/contrib/url/browser/trustedDomainService.service'
+export { IWebviewService } from 'vs/workbench/contrib/webview/browser/webview.service'
+export { IWebviewWorkbenchService } from 'vs/workbench/contrib/webviewPanel/browser/webviewWorkbenchService.service'
+export { IWebviewViewService } from 'vs/workbench/contrib/webviewView/browser/webviewViewService.service'
+export { IWalkthroughsService } from 'vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService.service'
+export { IAccessibleViewInformationService } from 'vs/workbench/services/accessibility/common/accessibleViewInformationService.service'
+export { IAiEmbeddingVectorService } from 'vs/workbench/services/aiEmbeddingVector/common/aiEmbeddingVectorService.service'
+export { IAiRelatedInformationService } from 'vs/workbench/services/aiRelatedInformation/common/aiRelatedInformation.service'
+export { IWorkbenchAssignmentService } from 'vs/workbench/services/assignment/common/assignmentService.service'
+export { IAuthenticationAccessService } from 'vs/workbench/services/authentication/browser/authenticationAccessService.service'
+export { IAuthenticationUsageService } from 'vs/workbench/services/authentication/browser/authenticationUsageService.service'
+export {
+  IAuthenticationExtensionsService,
+  IAuthenticationService
+} from 'vs/workbench/services/authentication/common/authentication.service'
+export { IAuxiliaryWindowService } from 'vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.service'
+export { IJSONEditingService } from 'vs/workbench/services/configuration/common/jsonEditing.service'
+export { IConfigurationResolverService } from 'vs/workbench/services/configurationResolver/common/configurationResolver.service'
+export { IDecorationsService } from 'vs/workbench/services/decorations/common/decorations.service'
+export { ICustomEditorLabelService } from 'vs/workbench/services/editor/common/customEditorLabelService.service'
+export { IEditorPaneService } from 'vs/workbench/services/editor/common/editorPaneService.service'
+export { IExtensionBisectService } from 'vs/workbench/services/extensionManagement/browser/extensionBisect.service'
+export { IExtensionFeaturesManagementService } from 'vs/workbench/services/extensionManagement/common/extensionFeatures.service'
+export {
+  IExtensionManagementServerService,
+  IWebExtensionsScannerService,
+  IWorkbenchExtensionEnablementService,
+  IWorkbenchExtensionManagementService
+} from 'vs/workbench/services/extensionManagement/common/extensionManagement.service'
+export {
+  IExtensionIgnoredRecommendationsService,
+  IExtensionRecommendationsService
+} from 'vs/workbench/services/extensionRecommendations/common/extensionRecommendations.service'
+export { IWorkspaceExtensionsConfigService } from 'vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig.service'
+export { IExtensionUrlHandler } from 'vs/workbench/services/extensions/browser/extensionUrlHandler.service'
+export { IExtensionManifestPropertiesService } from 'vs/workbench/services/extensions/common/extensionManifestPropertiesService.service'
+export { NullExtensionService } from 'vs/workbench/services/extensions/common/extensions'
+export { IExtensionService } from 'vs/workbench/services/extensions/common/extensions.service'
+export { IElevatedFileService } from 'vs/workbench/services/files/common/elevatedFileService.service'
+export { IIntegrityService } from 'vs/workbench/services/integrity/common/integrity.service'
+export { FallbackKeyboardMapper } from 'vs/workbench/services/keybinding/common/fallbackKeyboardMapper'
+export { ILanguageDetectionService } from 'vs/workbench/services/languageDetection/common/languageDetectionWorkerService.service'
+export { ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecycle.service'
+export { IActiveLanguagePackService } from 'vs/workbench/services/localization/common/locale.service'
+export { INotebookDocumentService } from 'vs/workbench/services/notebook/common/notebookDocumentService.service'
+export { IOutlineService } from 'vs/workbench/services/outline/browser/outline.service'
+export { ISearchService } from 'vs/workbench/services/search/common/search.service'
+export { IEmbedderTerminalService } from 'vs/workbench/services/terminal/common/embedderTerminalService.service'
+export { ITextMateTokenizationService } from 'vs/workbench/services/textMate/browser/textMateTokenizationFeature.service'
+export { IHostColorSchemeService } from 'vs/workbench/services/themes/common/hostColorSchemeService.service'
+export { ITimerService } from 'vs/workbench/services/timer/browser/timerService.service'
+export { IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService.service'
+export { IUserActivityService } from 'vs/workbench/services/userActivity/common/userActivityService.service'
+export { IUserDataInitializationService } from 'vs/workbench/services/userData/browser/userDataInit.service'
+export { IRemoteUserDataProfilesService } from 'vs/workbench/services/userDataProfile/common/remoteUserDataProfiles.service'
+export {
+  IUserDataProfileImportExportService,
+  IUserDataProfileManagementService,
+  IUserDataProfileService
+} from 'vs/workbench/services/userDataProfile/common/userDataProfile.service'
+export { UserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfileService'
+export { AccountStatus } from 'vs/workbench/services/userDataSync/common/userDataSync'
+export { IUserDataSyncWorkbenchService } from 'vs/workbench/services/userDataSync/common/userDataSync.service'
+export { IWorkingCopyBackupService } from 'vs/workbench/services/workingCopy/common/workingCopyBackup.service'
+export { IWorkingCopyEditorService } from 'vs/workbench/services/workingCopy/common/workingCopyEditorService.service'
+export { IWorkingCopyHistoryService } from 'vs/workbench/services/workingCopy/common/workingCopyHistory.service'
+export { IWorkingCopyService } from 'vs/workbench/services/workingCopy/common/workingCopyService.service'
+export { IWorkspaceEditingService } from 'vs/workbench/services/workspaces/common/workspaceEditing.service'
+export { IWorkspaceIdentityService } from 'vs/workbench/services/workspaces/common/workspaceIdentityService.service'
+export { IChatMarkdownAnchorService } from 'vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownAnchorService.service'
+export { getBuiltInExtensionTranslationsUris, getExtensionIdProvidingCurrentLocale } from './l10n'
+export { unsupported } from './tools'
+export { IChatEntitlementService } from 'vs/workbench/contrib/chat/common/chatEntitlementService.service'
+export { IPromptsService } from 'vs/workbench/contrib/chat/common/promptSyntax/service/types.service'
+export { ISuggestMemoryService } from 'vs/editor/contrib/suggest/browser/suggestMemory.service'
+export { LanguageConfigurationService } from 'vs/editor/common/languages/languageConfigurationRegistry'
+export { ISemanticTokensStylingService } from 'vs/editor/common/services/semanticTokensStyling.service'
+export { ILanguageFeatureDebounceService } from 'vs/editor/common/services/languageFeatureDebounce.service'
+export { IDiffProviderFactoryService } from 'vs/editor/browser/widget/diffEditor/diffProviderFactoryService.service'
+export { IOutlineModelService } from 'vs/editor/contrib/documentSymbols/browser/outlineModel.service'
+export { IMarkerNavigationService } from 'vs/editor/contrib/gotoError/browser/markerNavigationService.service'
+export { ICodeLensCache } from 'vs/editor/contrib/codelens/browser/codeLensCache.service'
+export { IInlayHintsCache } from 'vs/editor/contrib/inlayHints/browser/inlayHintsController.service'
+export { ISymbolNavigationService } from 'vs/editor/contrib/gotoSymbol/browser/symbolNavigation.service'
+export { IEditorCancellationTokens } from 'vs/editor/contrib/editorState/browser/keybindingCancellation.service'
+export { IPeekViewService } from 'vs/editor/contrib/peekView/browser/peekView.service'
+export { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo.service'
+export { IActionWidgetService } from 'vs/platform/actionWidget/browser/actionWidget.service'
+export {
+  IMcpSamplingService,
+  IMcpService,
+  IMcpWorkbenchService
+} from 'vs/workbench/contrib/mcp/common/mcpTypes.service'
+export { IMcpConfigPathsService } from 'vs/workbench/contrib/mcp/common/mcpConfigPathsService.service'
+export { IMcpRegistry } from 'vs/workbench/contrib/mcp/common/mcpRegistryTypes.service'
+export { IExtensionGalleryManifestService } from 'vs/platform/extensionManagement/common/extensionGalleryManifest.service'
+export {
+  ISharedWebContentExtractorService,
+  IWebContentExtractorService
+} from 'vs/platform/webContentExtractor/common/webContentExtractor.service'
+export { IDefaultAccountService } from 'vs/workbench/services/accounts/common/defaultAccount.service'
+export { NullDefaultAccountService } from 'vs/workbench/services/accounts/common/defaultAccount'
+export { IChatTransferService } from 'vs/workbench/contrib/chat/common/chatTransferService.service'
+export { IChatStatusItemService } from 'vs/workbench/contrib/chat/browser/chatStatusItemService.service'
+export { IAiSettingsSearchService } from 'vscode/src/vs/workbench/services/aiSettingsSearch/common/aiSettingsSearch.service'
+export { IDynamicAuthenticationProviderStorageService } from 'vs/workbench/services/authentication/common/dynamicAuthenticationProviderStorage.service'
+export { IAuthenticationMcpService } from 'vs/workbench/services/authentication/browser/authenticationMcpService.service'
+export { IAuthenticationMcpAccessService } from 'vs/workbench/services/authentication/browser/authenticationMcpAccessService.service'
+export { IAuthenticationMcpUsageService } from 'vs/workbench/services/authentication/browser/authenticationMcpUsageService.service'
+export { IBrowserElementsService } from 'vs/workbench/services/browserElements/browser/browserElementsService.service'
+export { IGettingStartedExperimentService } from 'vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedExpService.service'
+export { IChatContextPickService } from 'vs/workbench/contrib/chat/browser/chatContextPickService.service'
+export {
+  IMcpGalleryService,
+  IMcpManagementService
+} from 'vs/platform/mcp/common/mcpManagement.service'
+export { ITreeSitterThemeService } from 'vs/editor/common/services/treeSitter/treeSitterThemeService.service'
+export { ITreeSitterLibraryService } from 'vs/editor/common/services/treeSitter/treeSitterLibraryService.service'


### PR DESCRIPTION
Not a big deal, allows to remove this button from the interface (when using a server that has the language pack, and the client too):
![image](https://github.com/user-attachments/assets/3f075a0d-6aba-4936-affe-b85cf10114b4)
