### PR TITLE
fix: do not ignore call to openEditor from StandaloneEditorPane on a different model

### DIFF
--- a/src/service-override/editor.ts
+++ b/src/service-override/editor.ts
@@ -155,8 +155,16 @@ class EmptyEditorGroupsService implements IEditorGroupsService {
 }
 
 class MonacoEditorGroupsService extends MonacoDelegateEditorGroupsService<EmptyEditorGroupsService> {
-  constructor(@IInstantiationService instantiationService: IInstantiationService) {
-    super(instantiationService.createInstance(EmptyEditorGroupsService), true, instantiationService)
+  constructor(
+    openEditor: OpenEditor,
+    @IInstantiationService instantiationService: IInstantiationService
+  ) {
+    super(
+      instantiationService.createInstance(EmptyEditorGroupsService),
+      true,
+      openEditor,
+      instantiationService
+    )
   }
 }
 
@@ -169,7 +177,7 @@ export default function getServiceOverride(openEditor: OpenEditor): IEditorOverr
       true
     ),
     [ITextEditorService.toString()]: new SyncDescriptor(TextEditorService, [], false),
-    [IEditorGroupsService.toString()]: new SyncDescriptor(MonacoEditorGroupsService)
+    [IEditorGroupsService.toString()]: new SyncDescriptor(MonacoEditorGroupsService, [openEditor])
   }
 }
 

--- a/src/service-override/views.ts
+++ b/src/service-override/views.ts
@@ -197,8 +197,16 @@ class MonacoEditorParts
   extends MonacoDelegateEditorGroupsService<EditorParts>
   implements Omit<PublicInterface<EditorParts>, keyof IEditorGroupsService>
 {
-  constructor(@IInstantiationService instantiationService: IInstantiationService) {
-    super(instantiationService.createInstance(EditorParts), false, instantiationService)
+  constructor(
+    openEditorFallback: OpenEditor | undefined,
+    @IInstantiationService instantiationService: IInstantiationService
+  ) {
+    super(
+      instantiationService.createInstance(EditorParts),
+      false,
+      openEditorFallback,
+      instantiationService
+    )
   }
 
   getId(): string {
@@ -839,7 +847,11 @@ function getServiceOverride(
     ...getKeybindingsOverride({
       shouldUseGlobalKeybindings: isEditorPartVisible
     }),
-    [IEditorGroupsService.toString()]: new SyncDescriptor(MonacoEditorParts, [], false),
+    [IEditorGroupsService.toString()]: new SyncDescriptor(
+      MonacoEditorParts,
+      [openEditorFallback],
+      false
+    ),
     [IEditorService.toString()]: new SyncDescriptor(
       MonacoEditorService,
       [openEditorFallback, isEditorPartVisible],


### PR DESCRIPTION
Some internal commands (like "Open User Settings") are trying to open the file in the current editor pane, which is ignored with the current code instead of calling the openEditor callback