### PR TITLE
Fix extension bundle content loading when using data url

### DIFF
--- a/src/service-override/files.ts
+++ b/src/service-override/files.ts
@@ -1094,6 +1094,16 @@ class FileServiceOverride extends FileService {
     }
   }
 
+  override async withProvider(resource: URI) {
+    if (resource.scheme === 'data') {
+      const httpProvider = this.getProvider('http')
+      if (httpProvider != null) {
+        return httpProvider
+      }
+    }
+    return super.withProvider(resource)
+  }
+
   /**
    * Hack: the parent class has dependencies, we don't, dependencies are stored in a static field
    * Having no dependencies mean the field won't be overriden, so we'll inherit dependencies from the parent


### PR DESCRIPTION
[VSCode fetch the extension l10n bundles via the FileService](https://github.com/microsoft/vscode/blob/67eb75414b30401ac261031f7e47f7685a9a97bd/src/vs/workbench/api/browser/mainThreadLocalization.ts#L33-L36) and those file can be bundled as base64 data uris

the FileService currently fails to load them, which leads to default extension not being translated when the bundler decides to use data urls for those files