### PR TITLE
Prevent VSCode from breaking default extension sourcemap references

### DIFF
--- a/vscode-patches/0083-fix-stop-rewriting-source-maps.patch
+++ b/vscode-patches/0083-fix-stop-rewriting-source-maps.patch
@@ -1,0 +1,138 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lo=C3=AFc=20Mangeonjean?= <loic@coderpad.io>
+Date: Mon, 29 Sep 2025 12:24:50 +0200
+Subject: [PATCH] fix: stop rewriting source maps
+
+---
+ build/gulpfile.extensions.js |  5 +----
+ build/gulpfile.vscode.js     |  1 -
+ build/lib/extensions.js      | 13 -------------
+ build/lib/extensions.ts      | 14 --------------
+ 4 files changed, 1 insertion(+), 32 deletions(-)
+
+diff --git a/build/gulpfile.extensions.js b/build/gulpfile.extensions.js
+index 687bd16fd8c..ca84bc9fc6f 100644
+--- a/build/gulpfile.extensions.js
++++ b/build/gulpfile.extensions.js
+@@ -71,8 +71,6 @@ const compilations = [
+ 	'.vscode/extensions/vscode-selfhost-import-aid/tsconfig.json',
+ ];
+ 
+-const getBaseUrl = out => `https://main.vscode-cdn.net/sourcemaps/${commit}/${out}`;
+-
+ const tasks = compilations.map(function (tsconfigFile) {
+ 	const absolutePath = path.join(root, tsconfigFile);
+ 	const relativeDirname = path.dirname(tsconfigFile.replace(/^(.*\/)?extensions\//i, ''));
+@@ -88,7 +86,6 @@ const tasks = compilations.map(function (tsconfigFile) {
+ 	const srcOpts = { cwd: root, base: srcBase, dot: true };
+ 
+ 	const out = path.join(srcRoot, 'out');
+-	const baseUrl = getBaseUrl(out);
+ 
+ 	function createPipeline(build, emitError, transpileOnly) {
+ 		const tsb = require('./lib/tsb');
+@@ -117,7 +114,7 @@ const tasks = compilations.map(function (tsconfigFile) {
+ 				.pipe(compilation())
+ 				.pipe(build ? util.stripSourceMappingURL() : es.through())
+ 				.pipe(sourcemaps.write('.', {
+-					sourceMappingURL: !build ? null : f => `${baseUrl}/${f.relative}.map`,
++					sourceMappingURL: null,
+ 					addComment: !!build,
+ 					includeContent: !!build,
+ 					// note: trailing slash is important, else the source URLs in V8's file coverage are incorrect
+diff --git a/build/gulpfile.vscode.js b/build/gulpfile.vscode.js
+index ed06b6a5aa8..72bab050f5e 100644
+--- a/build/gulpfile.vscode.js
++++ b/build/gulpfile.vscode.js
+@@ -293,7 +293,6 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
+ 			.pipe(util.cleanNodeModules(path.join(__dirname, '.moduleignore')))
+ 			.pipe(util.cleanNodeModules(path.join(__dirname, `.moduleignore.${process.platform}`)))
+ 			.pipe(jsFilter)
+-			.pipe(util.rewriteSourceMappingURL(sourceMappingURLBase))
+ 			.pipe(jsFilter.restore)
+ 			.pipe(createAsar(path.join(process.cwd(), 'node_modules'), [
+ 				'**/*.node',
+diff --git a/build/lib/extensions.js b/build/lib/extensions.js
+index aeea722d372..d8e97d315da 100644
+--- a/build/lib/extensions.js
++++ b/build/lib/extensions.js
+@@ -69,12 +69,9 @@ const gulp_buffer_1 = __importDefault(require("gulp-buffer"));
+ const jsoncParser = __importStar(require("jsonc-parser"));
+ const dependencies_1 = require("./dependencies");
+ const builtInExtensions_1 = require("./builtInExtensions");
+-const getVersion_1 = require("./getVersion");
+ const fetch_1 = require("./fetch");
+ const vzip = require('gulp-vinyl-zip');
+ const root = path_1.default.dirname(path_1.default.dirname(__dirname));
+-const commit = (0, getVersion_1.getVersion)(root);
+-const sourceMappingURLBase = `https://main.vscode-cdn.net/sourcemaps/${commit}`;
+ function minifyExtensionResources(input) {
+     const jsonFilter = (0, gulp_filter_1.default)(['**/*.json', '**/*.code-snippets'], { restore: true });
+     return input
+@@ -189,7 +186,6 @@ function fromLocalWebpack(extensionPath, webpackConfigFileName, disableMangle) {
+                         }
+                     }
+                 }
+-                const relativeOutputPath = path_1.default.relative(extensionPath, webpackConfig.output.path);
+                 return webpackGulp(webpackConfig, webpack, webpackDone)
+                     .pipe(event_stream_1.default.through(function (data) {
+                     data.stat = data.stat || {};
+@@ -197,15 +193,6 @@ function fromLocalWebpack(extensionPath, webpackConfigFileName, disableMangle) {
+                     this.emit('data', data);
+                 }))
+                     .pipe(event_stream_1.default.through(function (data) {
+-                    // source map handling:
+-                    // * rewrite sourceMappingURL
+-                    // * save to disk so that upload-task picks this up
+-                    if (path_1.default.extname(data.basename) === '.js') {
+-                        const contents = data.contents.toString('utf8');
+-                        data.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=(.*)$/gm, function (_m, g1) {
+-                            return `\n//# sourceMappingURL=${sourceMappingURLBase}/extensions/${path_1.default.basename(extensionPath)}/${relativeOutputPath}/${g1}`;
+-                        }), 'utf8');
+-                    }
+                     this.emit('data', data);
+                 }));
+             });
+diff --git a/build/lib/extensions.ts b/build/lib/extensions.ts
+index b997fe4046e..d76b6ffd0f3 100644
+--- a/build/lib/extensions.ts
++++ b/build/lib/extensions.ts
+@@ -23,13 +23,10 @@ import * as jsoncParser from 'jsonc-parser';
+ import webpack from 'webpack';
+ import { getProductionDependencies } from './dependencies';
+ import { IExtensionDefinition, getExtensionStream } from './builtInExtensions';
+-import { getVersion } from './getVersion';
+ import { fetchUrls, fetchGithub } from './fetch';
+ const vzip = require('gulp-vinyl-zip');
+ 
+ const root = path.dirname(path.dirname(__dirname));
+-const commit = getVersion(root);
+-const sourceMappingURLBase = `https://main.vscode-cdn.net/sourcemaps/${commit}`;
+ 
+ function minifyExtensionResources(input: Stream): Stream {
+ 	const jsonFilter = filter(['**/*.json', '**/*.code-snippets'], { restore: true });
+@@ -162,7 +159,6 @@ function fromLocalWebpack(extensionPath: string, webpackConfigFileName: string,
+ 						}
+ 					}
+ 				}
+-				const relativeOutputPath = path.relative(extensionPath, webpackConfig.output.path);
+ 
+ 				return webpackGulp(webpackConfig, webpack, webpackDone)
+ 					.pipe(es.through(function (data) {
+@@ -171,16 +167,6 @@ function fromLocalWebpack(extensionPath: string, webpackConfigFileName: string,
+ 						this.emit('data', data);
+ 					}))
+ 					.pipe(es.through(function (data: File) {
+-						// source map handling:
+-						// * rewrite sourceMappingURL
+-						// * save to disk so that upload-task picks this up
+-						if (path.extname(data.basename) === '.js') {
+-							const contents = (<Buffer>data.contents).toString('utf8');
+-							data.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=(.*)$/gm, function (_m, g1) {
+-								return `\n//# sourceMappingURL=${sourceMappingURLBase}/extensions/${path.basename(extensionPath)}/${relativeOutputPath}/${g1}`;
+-							}), 'utf8');
+-						}
+-
+ 						this.emit('data', data);
+ 					}));
+ 			});


### PR DESCRIPTION
The VSCode default extension build process replaces the local sourcemap references by links to `https://main.vscode-cdn.net/sourcemaps/XXX`

It's an issue because:
- It's currently broken because the url contains `undefined` instead of the VSCode commit
- We may have patched the default extensions and the published sourcemap may not be corresponding to the code

I'm not sure why microsoft is doing such transformation :shrug: 

The change prevent vite from logging a lot of sourcemap errors