### PR TITLE
[FEAT] Allow to register a fileService stat middleware

### DIFF
--- a/vscode-patches/0013-feat-export-some-classes-and-make-some-methods-acces.patch
+++ b/vscode-patches/0013-feat-export-some-classes-and-make-some-methods-acces.patch
@@ -12,6 +12,7 @@ Subject: [PATCH] feat: export some classes and make some methods accessible
  .../platform/actionWidget/browser/actionWidget.ts  |  2 +-
  .../actions/browser/actionViewItemService.ts       |  2 +-
  .../browser/extensionResourceLoaderService.ts      |  2 +-
+ src/vs/platform/files/common/fileService.ts        |  6 +++---
  .../api/browser/statusBarExtensionPoint.ts         |  2 +-
  src/vs/workbench/browser/layout.ts                 | 10 +++++-----
  src/vs/workbench/browser/workbench.ts              | 14 +++++++-------
@@ -39,7 +40,7 @@ Subject: [PATCH] feat: export some classes and make some methods accessible
  .../terminal/common/embedderTerminalService.ts     |  2 +-
  .../common/remoteUserDataProfiles.ts               |  2 +-
  .../userDataSync/common/userDataSyncUtil.ts        |  2 +-
- 35 files changed, 60 insertions(+), 56 deletions(-)
+ 36 files changed, 63 insertions(+), 59 deletions(-)
 
 diff --git a/src/vs/editor/contrib/editorState/browser/keybindingCancellation.ts b/src/vs/editor/contrib/editorState/browser/keybindingCancellation.ts
 index 94020ce96b9..de1e9af237e 100644
@@ -167,6 +168,23 @@ index 921674ef18e..00b83a75fcb 100644
  
  	declare readonly _serviceBrand: undefined;
  
+diff --git a/src/vs/platform/files/common/fileService.ts b/src/vs/platform/files/common/fileService.ts
+index a5f6dc5023a..1220e0d5b6a 100644
+--- a/src/vs/platform/files/common/fileService.ts
++++ b/src/vs/platform/files/common/fileService.ts
+@@ -243,9 +243,9 @@ export class FileService extends Disposable implements IFileService {
+ 		});
+ 	}
+ 
+-	private async toFileStat(provider: IFileSystemProvider, resource: URI, stat: IStat | { type: FileType } & Partial<IStat>, siblings: number | undefined, resolveMetadata: boolean, recurse: (stat: IFileStat, siblings?: number) => boolean): Promise<IFileStat>;
+-	private async toFileStat(provider: IFileSystemProvider, resource: URI, stat: IStat, siblings: number | undefined, resolveMetadata: true, recurse: (stat: IFileStat, siblings?: number) => boolean): Promise<IFileStatWithMetadata>;
+-	private async toFileStat(provider: IFileSystemProvider, resource: URI, stat: IStat | { type: FileType } & Partial<IStat>, siblings: number | undefined, resolveMetadata: boolean, recurse: (stat: IFileStat, siblings?: number) => boolean): Promise<IFileStat> {
++	protected async toFileStat(provider: IFileSystemProvider, resource: URI, stat: IStat | { type: FileType } & Partial<IStat>, siblings: number | undefined, resolveMetadata: boolean, recurse: (stat: IFileStat, siblings?: number) => boolean): Promise<IFileStat>;
++	protected async toFileStat(provider: IFileSystemProvider, resource: URI, stat: IStat, siblings: number | undefined, resolveMetadata: true, recurse: (stat: IFileStat, siblings?: number) => boolean): Promise<IFileStatWithMetadata>;
++	protected async toFileStat(provider: IFileSystemProvider, resource: URI, stat: IStat | { type: FileType } & Partial<IStat>, siblings: number | undefined, resolveMetadata: boolean, recurse: (stat: IFileStat, siblings?: number) => boolean): Promise<IFileStat> {
+ 		const { providerExtUri } = this.getExtUri(provider);
+ 
+ 		// convert to file stat
 diff --git a/src/vs/workbench/api/browser/statusBarExtensionPoint.ts b/src/vs/workbench/api/browser/statusBarExtensionPoint.ts
 index fa0d7fd2307..46a8443e46a 100644
 --- a/src/vs/workbench/api/browser/statusBarExtensionPoint.ts

--- a/vscode-patches/0045-refactor-split-code-to-be-able-to-import-only-requir.patch
+++ b/vscode-patches/0045-refactor-split-code-to-be-able-to-import-only-requir.patch
@@ -337,7 +337,7 @@ index 8697dcb34d4..5d7426ab0db 100644
  
  interface IExtensionCacheData {
 diff --git a/src/vs/platform/files/common/fileService.ts b/src/vs/platform/files/common/fileService.ts
-index a5f6dc5023a..313c0ef2b26 100644
+index 1220e0d5b6a..c1e984953dd 100644
 --- a/src/vs/platform/files/common/fileService.ts
 +++ b/src/vs/platform/files/common/fileService.ts
 @@ -23,6 +23,64 @@ import { readFileIntoStream } from './io.js';


### PR DESCRIPTION
allows to do for instance:

```typescript
    ...getFilesServiceOverride({
      async statMiddleware(resource, next) {
        const stat = await next()
        if (resource.path === '/workspace/test.css') {
          return {
            ...stat,
            readonly: true
          }
        }
        return stat
      }
    })
```

can be used to force some file to be considered as readonly for instance