### PR TITLE
Add policy service override

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -235,6 +235,7 @@
         "@codingame/monaco-vscode-performance-service-override": "file:../dist/packages/monaco-vscode-performance-service-override",
         "@codingame/monaco-vscode-perl-default-extension": "file:../dist/packages/monaco-vscode-perl-default-extension",
         "@codingame/monaco-vscode-php-default-extension": "file:../dist/packages/monaco-vscode-php-default-extension",
+        "@codingame/monaco-vscode-policy-service-override": "file:../dist/packages/monaco-vscode-policy-service-override",
         "@codingame/monaco-vscode-powershell-default-extension": "file:../dist/packages/monaco-vscode-powershell-default-extension",
         "@codingame/monaco-vscode-preferences-service-override": "file:../dist/packages/monaco-vscode-preferences-service-override",
         "@codingame/monaco-vscode-process-explorer-service-override": "file:../dist/packages/monaco-vscode-process-explorer-service-override",
@@ -2821,6 +2822,14 @@
         "@codingame/monaco-vscode-api": "0.0.0-semantic-release"
       }
     },
+    "node_modules/@codingame/monaco-vscode-policy-service-override": {
+      "version": "0.0.0-semantic-release",
+      "resolved": "file:../dist/packages/monaco-vscode-policy-service-override",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "0.0.0-semantic-release"
+      }
+    },
     "node_modules/@codingame/monaco-vscode-powershell-default-extension": {
       "version": "0.0.0-semantic-release",
       "resolved": "file:../dist/packages/monaco-vscode-powershell-default-extension",
@@ -5034,7 +5043,8 @@
       "version": "5.6.0-beta.137",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.6.0-beta.137.tgz",
       "integrity": "sha512-ldWd6SNigVXl9Wl9zhzJT0qO8iK5t82iCO86hX5LeJr8X8lWwED22ZDvw4QGIp/2/PyTXA5AxHriLQ/ZfJElgw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -6199,6 +6209,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6750,7 +6761,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",

--- a/demo/package.json
+++ b/demo/package.json
@@ -262,6 +262,7 @@
     "@codingame/monaco-vscode-performance-service-override": "file:../dist/packages/monaco-vscode-performance-service-override",
     "@codingame/monaco-vscode-perl-default-extension": "file:../dist/packages/monaco-vscode-perl-default-extension",
     "@codingame/monaco-vscode-php-default-extension": "file:../dist/packages/monaco-vscode-php-default-extension",
+    "@codingame/monaco-vscode-policy-service-override": "file:../dist/packages/monaco-vscode-policy-service-override",
     "@codingame/monaco-vscode-powershell-default-extension": "file:../dist/packages/monaco-vscode-powershell-default-extension",
     "@codingame/monaco-vscode-preferences-service-override": "file:../dist/packages/monaco-vscode-preferences-service-override",
     "@codingame/monaco-vscode-process-explorer-service-override": "file:../dist/packages/monaco-vscode-process-explorer-service-override",

--- a/src/service-override/policy.ts
+++ b/src/service-override/policy.ts
@@ -1,0 +1,24 @@
+import type { PolicyName } from 'vs/base/common/policy'
+import type { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
+import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
+import { AbstractPolicyService, type PolicyValue } from 'vs/platform/policy/common/policy'
+import { IPolicyService } from 'vs/platform/policy/common/policy.service'
+
+class PolicyService extends AbstractPolicyService {
+  constructor(policies: Map<PolicyName, PolicyValue>) {
+    super()
+    this.policies = policies
+  }
+
+  protected override async _updatePolicyDefinitions(): Promise<void> {}
+}
+
+export default function getServiceOverride(
+  policies: Map<PolicyName, PolicyValue>
+): IEditorOverrideServices {
+  return {
+    [IPolicyService.toString()]: new SyncDescriptor(PolicyService, [policies], true)
+  }
+}
+
+export type { PolicyName, PolicyValue }


### PR DESCRIPTION
Allows to apply some policies, like limiting the installable extensions:

```typescript
  ...getPolicyServiceOverride(
    new Map(
      Object.entries({
        AllowedExtensions: JSON.stringify({
          github: true,
          microsoft: true,
          codingame: true
        })
      })
    )
  )
```

see https://code.visualstudio.com/docs/setup/enterprise#_configure-allowed-extensions