### PR TITLE
fix: respect isRegExp option in WorkspaceSearchProvider

### DIFF
--- a/src/service-override/tools/search-providers/workspace-search-provider.ts
+++ b/src/service-override/tools/search-providers/workspace-search-provider.ts
@@ -1,5 +1,5 @@
 import { BaseWorkspaceSearchProvider } from '../search-utils/base-provider'
-import { fuzzyContains, splitLines } from 'vs/base/common/strings'
+import { fuzzyContains, splitLines, createRegExp } from 'vs/base/common/strings'
 import type { URI } from 'vs/base/common/uri'
 import * as glob from 'vs/base/common/glob'
 import type {
@@ -270,12 +270,13 @@ export class WorkspaceSearchProvider
    */
   private createSearchRegex(contentPattern: ITextQuery['contentPattern']): RegExp {
     try {
-      return new RegExp(
-        contentPattern.pattern || '',
-        (contentPattern.isCaseSensitive ? 'g' : 'gi') +
-          (contentPattern.isMultiline ? 'm' : '') +
-          (contentPattern.isUnicode ? 'u' : '')
-      )
+      return createRegExp(contentPattern.pattern || '', !!contentPattern.isRegExp, {
+        wholeWord: contentPattern.isWordMatch,
+        global: true,
+        matchCase: contentPattern.isCaseSensitive,
+        multiline: contentPattern.isMultiline,
+        unicode: contentPattern.isUnicode
+      })
     } catch (regexError) {
       this.logger.error(`Invalid regex pattern: ${contentPattern.pattern}`, regexError as Error)
       const searchError = new SearchError(


### PR DESCRIPTION
Fixes #756 

I tested it using the demo, seem to work fine

Note:
vscode sets `multiline` and `unicode` always to true, regardless of the parameters (https://github.com/microsoft/vscode/blob/eba6411f8aee3458c64046b5af0b68ea801fae40/src/vs/workbench/services/search/worker/localFileSearch.ts#L300C10-L300C28). I kept using the parameters here, like the previous implementation. I do not know which is the better approach

Edit: I guess this also fixes `isWordMatch`