### PR TITLE
fix(layout): correct mainContainerDimension

### DIFF
--- a/src/service-override/layout.ts
+++ b/src/service-override/layout.ts
@@ -546,7 +546,7 @@ export class LayoutService extends Disposable implements ILayoutService, IWorkbe
   }
 
   layout(): void {
-    this._mainContainerDimension = dom.getClientArea(window.document.body)
+    this._mainContainerDimension = dom.getClientArea(this.mainContainer)
 
     this._onDidLayout.fire(this._mainContainerDimension)
   }


### PR DESCRIPTION
```js  
get mainContainerDimension(): dom.IDimension {
    return this._mainContainerDimension
  }
```
this always return the document.body dimension.
when container is not body,  the quick input widget will offset;

so changes below
```js
layout(): void {
  //this._mainContainerDimension = dom.getClientArea(window.document.body)
    this._mainContainerDimension = dom.getClientArea(this.mainContainer)

    this._onDidLayout.fire(this._mainContainerDimension)
  }
```