### PR TITLE
fix(views): register a fallback default view container so contributed views don't crash registration

### DIFF
--- a/src/service-override/viewCommon.ts
+++ b/src/service-override/viewCommon.ts
@@ -1,5 +1,12 @@
 import type { IEditorOverrideServices } from 'vs/editor/standalone/browser/standaloneServices'
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors'
+import { Registry } from 'vs/platform/registry/common/platform'
+import {
+  Extensions as ViewContainerExtensions,
+  type IViewContainersRegistry,
+  ViewContainerLocation
+} from 'vs/workbench/common/views'
+import { ViewPaneContainer } from 'vs/workbench/browser/parts/views/viewPaneContainer'
 import { IViewDescriptorService } from 'vs/workbench/common/views.service'
 import { ViewDescriptorService } from 'vs/workbench/services/views/browser/viewDescriptorService'
 import { IActivityService } from 'vs/workbench/services/activity/common/activity.service'
@@ -104,7 +111,42 @@ registerServiceInitializePostParticipant(async (accessor) => {
   accessor.get(IHistoryService)
 })
 
+const EXPLORER_VIEW_CONTAINER_ID = 'workbench.view.explorer'
+/**
+ * VS Code's `views` extension-point resolves a contributed view's target as
+ * `container ?? getDefaultViewContainer()`, where getDefaultViewContainer() returns
+ * `viewContainersRegistry.get('workbench.view.explorer')`. In a partial setup that
+ * doesn't include the files explorer, that container is missing and the fallback
+ * throws (it reads `.extensionId` off `undefined`) — uncaught, aborting the ENTIRE
+ * contributes.views pass so every extension's contributed views fail to register.
+ * Register a minimal hidden-when-empty default Sidebar container under that id when
+ * none exists, so the fallback resolves and views degrade gracefully. See #804.
+ */
+function ensureDefaultViewContainer(): void {
+  const registry = Registry.as<IViewContainersRegistry>(
+    ViewContainerExtensions.ViewContainersRegistry
+  )
+  if (registry.get(EXPLORER_VIEW_CONTAINER_ID) != null) {
+    return
+  }
+  registry.registerViewContainer(
+    {
+      id: EXPLORER_VIEW_CONTAINER_ID,
+      title: { value: 'Explorer', original: 'Explorer' },
+      ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [
+        EXPLORER_VIEW_CONTAINER_ID,
+        { mergeViewWithContainerWhenSingleView: true }
+      ]),
+      hideIfEmpty: true,
+      order: 0
+    },
+    ViewContainerLocation.Sidebar,
+    { isDefault: true }
+  )
+}
+
 function getServiceOverride(_webviewIframeAlternateDomains?: string): IEditorOverrideServices {
+  ensureDefaultViewContainer()
   if (_webviewIframeAlternateDomains != null) {
     webviewIframeAlternateDomains = _webviewIframeAlternateDomains
   }


### PR DESCRIPTION
### What
Register a minimal default **Sidebar** view container (`workbench.view.explorer`) inside the views service-override when none exists, so VS Code's `views` extension-point fallback resolves instead of throwing.

### Why
In a partial setup that doesn't include the files explorer, `ViewsExtensionHandler.addViews` resolves a contributed view's target container as `container ?? getDefaultViewContainer()`, where `getDefaultViewContainer()` is `viewContainersRegistry.get('workbench.view.explorer')`. With no Explorer registered that's `undefined`, and the next line reads `.extensionId` off it → an **uncaught** `TypeError`, which aborts the **entire** `contributes.views` pass. The net effect: *every* extension's contributed sidebar views silently fail to register (hit with `anthropic.claude-code` and `openai.chatgpt`, but it's generic — `ms-vscode.js-debug` contributing into the missing `debug` container triggers it too).

Stack:
```
TypeError: Cannot read properties of undefined (reading 'extensionId')
    at ViewsRegistry.addViews (Array.forEach)
    at …_handleExtensionPoint
    at …_resolveAndProcessExtensions
    at …_initialize
```

Full investigation + traces: #804.

### Change
`ensureDefaultViewContainer()` in `src/service-override/views.ts`, called at the top of `getServiceOverride()`. It registers a `hideIfEmpty` default Sidebar container **only if** `workbench.view.explorer` isn't already registered, so setups that DO include the explorer (or already register it) are unaffected. This mirrors the workaround discussed in #804.

### Notes
- An alternative would be a defensive null-guard in `viewsExtensionPoint.addViews` (a `vscode-patch`) so the fallback degrades without throwing even when no default container exists at all — happy to switch to that approach instead if you'd prefer it.
- Verified in our app: the repeated uncaught `extensionId` crash drops to **0** and contributed sidebar views register + render (a remote extension's sidebar webview-view now shows). I was **not** able to run the full repo build locally (it pulls the VS Code sources via `install-vscode`), so please rely on CI / a quick local check for the build.

Refs #804
