### PR TITLE
Fix style conflict

### DIFF
--- a/vscode-patches/0060-feat-support-shadow-dom.patch
+++ b/vscode-patches/0060-feat-support-shadow-dom.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] feat: support shadow dom
 
 ---
  src/vs/base/browser/dom.ts                    | 61 ++++++++++++++++---
- src/vs/base/browser/domStylesheets.ts         | 21 +++++--
+ src/vs/base/browser/domStylesheets.ts         | 22 ++++---
  src/vs/base/browser/keyboardEvent.ts          | 12 +++-
  .../browser/ui/contextview/contextview.ts     |  2 +-
  src/vs/base/browser/ui/dialog/dialog.ts       |  6 +-
@@ -42,14 +42,16 @@ Subject: [PATCH] feat: support shadow dom
  .../view/renderers/backLayerWebView.ts        |  3 +-
  .../browser/preferences.contribution.ts       |  3 +-
  .../preferences/browser/settingsEditor2.ts    |  6 +-
+ .../terminal/browser/terminalService.ts       |  7 +--
  .../terminal/browser/terminalTabbedView.ts    |  2 +-
  .../contrib/terminal/browser/terminalView.ts  |  2 +-
  .../contrib/webview/browser/webviewElement.ts | 12 ++--
  .../browser/gettingStarted.ts                 |  4 +-
  .../browser/walkThroughPart.ts                |  6 +-
+ .../browser/auxiliaryWindowService.ts         |  6 +-
  .../suggest/browser/simpleSuggestWidget.ts    |  4 +-
- .../themes/browser/workbenchThemeService.ts   |  2 +-
- 45 files changed, 192 insertions(+), 99 deletions(-)
+ .../themes/browser/workbenchThemeService.ts   | 33 +++++++++-
+ 47 files changed, 227 insertions(+), 109 deletions(-)
 
 diff --git a/src/vs/base/browser/dom.ts b/src/vs/base/browser/dom.ts
 index e943bf0a557..6ebc4568a39 100644
@@ -180,13 +182,23 @@ index e943bf0a557..6ebc4568a39 100644
  		parentFocusable?.focus();
  	}
 diff --git a/src/vs/base/browser/domStylesheets.ts b/src/vs/base/browser/domStylesheets.ts
-index 72fa42df1a6..369b16a0e5a 100644
+index 72fa42df1a6..f82797cdd26 100644
 --- a/src/vs/base/browser/domStylesheets.ts
 +++ b/src/vs/base/browser/domStylesheets.ts
-@@ -39,6 +39,14 @@ class WrappedStyleElement extends Disposable {
+@@ -26,7 +26,7 @@ class WrappedStyleElement extends Disposable {
+ 		this._currentCssStyle = cssStyle;
+ 
+ 		if (!this._styleSheet) {
+-			this._styleSheet = createStyleSheet(mainWindow.document.head, s => s.textContent = cssStyle, this._store);
++			this._styleSheet = createStyleSheet(undefined, s => s.textContent = cssStyle, this._store);
+ 		} else {
+ 			this._styleSheet.textContent = cssStyle;
+ 		}
+@@ -39,7 +39,15 @@ class WrappedStyleElement extends Disposable {
  	}
  }
  
+-export function createStyleSheet(container: HTMLElement = mainWindow.document.head, beforeAppend?: (style: HTMLStyleElement) => void, disposableStore?: DisposableStore): HTMLStyleElement {
 +export let shadowRootContainer: ShadowRoot | undefined;
 +export function setContainerElement(container: HTMLElement) {
 +	const root = container.getRootNode();
@@ -195,24 +207,29 @@ index 72fa42df1a6..369b16a0e5a 100644
 +	}
 +}
 +
- export function createStyleSheet(container: HTMLElement = mainWindow.document.head, beforeAppend?: (style: HTMLStyleElement) => void, disposableStore?: DisposableStore): HTMLStyleElement {
++export function createStyleSheet(container: HTMLElement | ShadowRoot = shadowRootContainer ?? mainWindow.document.head, beforeAppend?: (style: HTMLStyleElement) => void, disposableStore?: DisposableStore): HTMLStyleElement {
  	const style = document.createElement('style');
  	style.type = 'text/css';
-@@ -64,7 +72,12 @@ export function createStyleSheet(container: HTMLElement = mainWindow.document.he
+ 	style.media = 'screen';
+@@ -52,7 +60,7 @@ export function createStyleSheet(container: HTMLElement = mainWindow.document.he
+ 
+ 	// With <head> as container, the stylesheet becomes global and is tracked
+ 	// to support auxiliary windows to clone the stylesheet.
+-	if (container === mainWindow.document.head) {
++	if (container === (shadowRootContainer ?? mainWindow.document.head)) {
+ 		const globalStylesheetClones = new Set<HTMLStyleElement>();
+ 		globalStylesheets.set(style, globalStylesheetClones);
+ 		if (disposableStore) {
+@@ -64,7 +72,7 @@ export function createStyleSheet(container: HTMLElement = mainWindow.document.he
  				continue; // main window is already tracked
  			}
  
 -			const cloneDisposable = disposables.add(cloneGlobalStyleSheet(style, globalStylesheetClones, targetWindow));
 +			const cloneDisposable = disposables.add(cloneGlobalStyleSheet(style, globalStylesheetClones, targetWindow.document.head));
-+			disposableStore?.add(cloneDisposable);
-+		}
-+
-+		if (shadowRootContainer !== undefined) {
-+			const cloneDisposable = cloneGlobalStyleSheet(style, globalStylesheetClones, shadowRootContainer);
  			disposableStore?.add(cloneDisposable);
  		}
  	}
-@@ -76,17 +89,17 @@ export function cloneGlobalStylesheets(targetWindow: Window): IDisposable {
+@@ -76,17 +84,17 @@ export function cloneGlobalStylesheets(targetWindow: Window): IDisposable {
  	const disposables = new DisposableStore();
  
  	for (const [globalStylesheet, clonedGlobalStylesheets] of globalStylesheets) {
@@ -1074,6 +1091,45 @@ index c754843a640..ab5ca9b057b 100644
  	}
  
  	private refreshSingleElement(element: SettingsTreeSettingElement): void {
+diff --git a/src/vs/workbench/contrib/terminal/browser/terminalService.ts b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+index effcc11e410..c3e617145a8 100644
+--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
++++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+@@ -53,7 +53,7 @@ import { mark } from '../../../../base/common/performance.js';
+ import { DetachedTerminal } from './detachedTerminal.js';
+ import { ITerminalCapabilityImplMap, TerminalCapability } from '../../../../platform/terminal/common/capabilities/capabilities.js';
+ import { createInstanceCapabilityEventMultiplexer } from './terminalEvents.js';
+-import { isAuxiliaryWindow, mainWindow } from '../../../../base/browser/window.js';
++import { isAuxiliaryWindow } from '../../../../base/browser/window.js';
+ import { GroupIdentifier } from '../../../common/editor.js';
+ import { getActiveWindow } from '../../../../base/browser/dom.js';
+ import { hasKey, isString } from '../../../../base/common/types.js';
+@@ -238,7 +238,7 @@ export class TerminalService extends Disposable implements ITerminalService {
+ 		this._initializePrimaryBackend();
+ 
+ 		// Create async as the class depends on `this`
+-		timeout(0).then(() => this._register(this._instantiationService.createInstance(TerminalEditorStyle, mainWindow.document.head)));
++		timeout(0).then(() => this._register(this._instantiationService.createInstance(TerminalEditorStyle)));
+ 	}
+ 
+ 	async showProfileQuickPick(type: 'setDefault' | 'createInstance', cwd?: string | URI): Promise<ITerminalInstance | undefined> {
+@@ -1395,7 +1395,6 @@ class TerminalEditorStyle extends Themable {
+ 	private _styleElement: HTMLElement;
+ 
+ 	constructor(
+-		container: HTMLElement,
+ 		@ITerminalService private readonly _terminalService: ITerminalService,
+ 		@IThemeService private readonly _themeService: IThemeService,
+ 		@ITerminalProfileService private readonly _terminalProfileService: ITerminalProfileService,
+@@ -1403,7 +1402,7 @@ class TerminalEditorStyle extends Themable {
+ 	) {
+ 		super(_themeService);
+ 		this._registerListeners();
+-		this._styleElement = domStylesheets.createStyleSheet(container);
++		this._styleElement = domStylesheets.createStyleSheet();
+ 		this._register(toDisposable(() => this._styleElement.remove()));
+ 		this.updateStyles();
+ 	}
 diff --git a/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts b/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
 index 7a3dd584458..b58e3170ff1 100644
 --- a/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
@@ -1191,6 +1247,37 @@ index c6fb17f8525..8691b2f7a37 100644
  		while (active && active !== this.content) {
  			active = active.parentElement;
  		}
+diff --git a/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts b/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
+index 15b221bafb8..0dc8b7ce37a 100644
+--- a/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
++++ b/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
+@@ -469,6 +469,8 @@ export class BrowserAuxiliaryWindowService extends Disposable implements IAuxili
+ 			mapOriginalToClone.set(originalNode, clonedNode);
+ 		}
+ 
++		const container = shadowRootContainer ?? mainWindow.document.head;
++
+ 		// Clone all style elements and stylesheet links from the window to the child window
+ 		// and keep track of <link> elements to settle to signal that styles have loaded
+ 		// Increment pending links right from the beginning to ensure we only settle when
+@@ -476,7 +478,7 @@ export class BrowserAuxiliaryWindowService extends Disposable implements IAuxili
+ 		pendingLinksToSettle++;
+ 		try {
+ 			// eslint-disable-next-line no-restricted-syntax
+-			for (const originalNode of mainWindow.document.head.querySelectorAll('link[rel="stylesheet"], style')) {
++			for (const originalNode of container.querySelectorAll('link[rel="stylesheet"], style')) {
+ 				cloneNode(originalNode);
+ 			}
+ 		} finally {
+@@ -490,7 +492,7 @@ export class BrowserAuxiliaryWindowService extends Disposable implements IAuxili
+ 
+ 		// Listen to new stylesheets as they are being added or removed in the main window
+ 		// and apply to child window (including changes to existing stylesheets elements)
+-		disposables.add(sharedMutationObserver.observe(mainWindow.document.head, disposables, { childList: true, subtree: true })(mutations => {
++		disposables.add(sharedMutationObserver.observe(container, disposables, { childList: true, subtree: true })(mutations => {
+ 			for (const mutation of mutations) {
+ 				if (
+ 					mutation.type !== 'childList' ||						// only interested in added/removed nodes
 diff --git a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
 index 1245acce54c..a2312b0d332 100644
 --- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -1214,15 +1301,55 @@ index 1245acce54c..a2312b0d332 100644
  			return;
  		}
 diff --git a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
-index 99405e3d855..07b705e99e7 100644
+index 99405e3d855..2f96d707b62 100644
 --- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
 +++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
-@@ -874,7 +874,7 @@ class ThemeFileWatcher {
+@@ -18,7 +18,7 @@ import { Event, Emitter } from '../../../../base/common/event.js';
+ import { registerFileIconThemeSchemas } from '../common/fileIconThemeSchema.js';
+ import { IDisposable, Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+ import { FileIconThemeData, FileIconThemeLoader } from './fileIconThemeData.js';
+-import { createStyleSheet } from '../../../../base/browser/domStylesheets.js';
++import { createStyleSheet, shadowRootContainer } from '../../../../base/browser/domStylesheets.js';
+ import { IBrowserWorkbenchEnvironmentService } from '../../environment/browser/environmentService.js';
+ import { IFileService, FileChangeType } from '../../../../platform/files/common/files.js';
+ import { URI } from '../../../../base/common/uri.js';
+@@ -872,9 +872,38 @@ class ThemeFileWatcher {
+ 	}
+ }
  
++const injectedFontFaces = new Set();
++function injectFontFacesInHead(styleSheetContent: string) {
++	const sheet = new mainWindow.CSSStyleSheet();
++	sheet.replaceSync(styleSheetContent);
++	const fontFaces = Array.from(sheet.cssRules)
++		.filter((rule) => rule instanceof mainWindow.CSSFontFaceRule)
++		.map((r) => r.cssText);
++	const missingFontFaces = fontFaces.filter((fontFace) => !injectedFontFaces.has(fontFace));
++
++	if (missingFontFaces.length > 0) {
++		const fontFaceStyleSheet = new mainWindow.CSSStyleSheet();
++		for (const fontFace of missingFontFaces) {
++			fontFaceStyleSheet.insertRule(fontFace);
++		}
++		mainWindow.document.adoptedStyleSheets = [
++			...mainWindow.document.adoptedStyleSheets,
++			fontFaceStyleSheet
++		];
++	}
++}
++
  function _applyRules(styleSheetContent: string, rulesClassName: string) {
++	if (shadowRootContainer) {
++		// Font-faces injected in shadow doms are ignored
++		// They need to be injected in the page head
++		// So we need to extract them and inject it in the head by hands if the container is a shadow dom
++		injectFontFacesInHead(styleSheetContent);
++	}
++
++	const container: HTMLElement | ShadowRoot = shadowRootContainer ?? mainWindow.document.head;
  	// eslint-disable-next-line no-restricted-syntax
 -	const themeStyles = mainWindow.document.head.getElementsByClassName(rulesClassName);
-+	const themeStyles = mainWindow.document.head.querySelectorAll(`.${rulesClassName}`);
++	const themeStyles = container.querySelectorAll(`.${rulesClassName}`);
  	if (themeStyles.length === 0) {
  		const elStyle = createStyleSheet();
  		elStyle.className = rulesClassName;

--- a/vscode-patches/0061-feat-support-adoptedStyleSheets-for-aux-windows.patch
+++ b/vscode-patches/0061-feat-support-adoptedStyleSheets-for-aux-windows.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] feat: support adoptedStyleSheets for aux windows
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts b/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
-index 15b221bafb8..3adc42984d0 100644
+index 0dc8b7ce37a..6c094a64793 100644
 --- a/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
 +++ b/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
 @@ -5,7 +5,7 @@

--- a/vscode-patches/0067-feat-support-loading-VSCode-in-an-iframe.patch
+++ b/vscode-patches/0067-feat-support-loading-VSCode-in-an-iframe.patch
@@ -195,7 +195,7 @@ index cc9e8f332c6..d06887a7eb2 100644
  
  export const EventType = {
 diff --git a/src/vs/base/browser/domStylesheets.ts b/src/vs/base/browser/domStylesheets.ts
-index 369b16a0e5a..99969bde5a8 100644
+index f82797cdd26..ac0e5a6cb12 100644
 --- a/src/vs/base/browser/domStylesheets.ts
 +++ b/src/vs/base/browser/domStylesheets.ts
 @@ -6,7 +6,7 @@

--- a/vscode-patches/0068-feat-mark-elements-created-outside-of-the-VSCode-con.patch
+++ b/vscode-patches/0068-feat-mark-elements-created-outside-of-the-VSCode-con.patch
@@ -21,10 +21,10 @@ index d06887a7eb2..25103157ef1 100644
  	return element;
  }
 diff --git a/src/vs/base/browser/domStylesheets.ts b/src/vs/base/browser/domStylesheets.ts
-index 99969bde5a8..2ab675b7895 100644
+index ac0e5a6cb12..69c2ea9408e 100644
 --- a/src/vs/base/browser/domStylesheets.ts
 +++ b/src/vs/base/browser/domStylesheets.ts
-@@ -51,6 +51,7 @@ export function createStyleSheet(container: HTMLElement = mainWindow.document.he
+@@ -51,6 +51,7 @@ export function createStyleSheet(container: HTMLElement | ShadowRoot = shadowRoo
  	const style = document.createElement('style');
  	style.type = 'text/css';
  	style.media = 'screen';

--- a/vscode-patches/0069-feat-centralize-element-creation-to-be-able-to-creat.patch
+++ b/vscode-patches/0069-feat-centralize-element-creation-to-be-able-to-creat.patch
@@ -406,7 +406,7 @@ index 942bf6e8315..a3f602cbb4e 100644
  	fragment.appendChild(textNode);
  	while (node.firstChild) {
 diff --git a/src/vs/base/browser/domStylesheets.ts b/src/vs/base/browser/domStylesheets.ts
-index 2ab675b7895..5ada59c00db 100644
+index 69c2ea9408e..6f8f9d62c25 100644
 --- a/src/vs/base/browser/domStylesheets.ts
 +++ b/src/vs/base/browser/domStylesheets.ts
 @@ -6,7 +6,7 @@
@@ -421,7 +421,7 @@ index 2ab675b7895..5ada59c00db 100644
 @@ -48,7 +48,7 @@ export function setContainerElement(container: HTMLElement) {
  }
  
- export function createStyleSheet(container: HTMLElement = mainWindow.document.head, beforeAppend?: (style: HTMLStyleElement) => void, disposableStore?: DisposableStore): HTMLStyleElement {
+ export function createStyleSheet(container: HTMLElement | ShadowRoot = shadowRootContainer ?? mainWindow.document.head, beforeAppend?: (style: HTMLStyleElement) => void, disposableStore?: DisposableStore): HTMLStyleElement {
 -	const style = document.createElement('style');
 +	const style = createElement('style');
  	style.type = 'text/css';

--- a/vscode-patches/0070-fix-close-auxiliary-window-when-the-context-is-unloa.patch
+++ b/vscode-patches/0070-fix-close-auxiliary-window-when-the-context-is-unloa.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] fix: close auxiliary window when the context is unloaded
  1 file changed, 6 insertions(+)
 
 diff --git a/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts b/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
-index 3adc42984d0..412c22ccf9e 100644
+index 6c094a64793..8ae4e7f8e47 100644
 --- a/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
 +++ b/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
 @@ -154,6 +154,12 @@ export class AuxiliaryWindow extends BaseWindow implements IAuxiliaryWindow {

--- a/vscode-patches/0078-refactor-extract-shouldAttemptTaskReconnection-flag.patch
+++ b/vscode-patches/0078-refactor-extract-shouldAttemptTaskReconnection-flag.patch
@@ -33,7 +33,7 @@ index 36209197e92..01d8342874e 100644
  			this._tasksReconnected = true;
  			this._storageService.remove(AbstractTaskService.PersistentTasks_Key, StorageScope.WORKSPACE);
 diff --git a/src/vs/workbench/contrib/terminal/browser/terminalService.ts b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
-index effcc11e410..c3cf2fc53ff 100644
+index c3e617145a8..eb5f3fabc31 100644
 --- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
 +++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
 @@ -42,7 +42,7 @@ import { IEditorGroupsService } from '../../../services/editor/common/editorGrou


### PR DESCRIPTION
By only injecting the styles in the shadow dom

Basically, when using the sandbox+shadow dom mode AND a regular editor in the same page, both vscode instances are conflicting on the styles

Currently, dynamic styles are injected into the document head, and then synchronized with the shadow dom.
Now, the dynamic styles are only injected in the shadow dom, except for font-faces that are extracted and injected into the page head, just like what is already done [here](https://github.com/CodinGame/monaco-vscode-api/blob/c88b9fb9dffcfb839da8a451c978f6d405436125/src/css.ts#L24-L40) for static stylesheets